### PR TITLE
Update copyright and author information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "json-schema-to-nickel"
 version = "0.1.0"
 edition = "2021"
-authors = ["Matthew Toohey <contact@mtoohey.com>"]
+authors = ["Matthew Toohey <contact@mtoohey.com>", "Viktor Kleen <viktor.kleen@tweag.io>"]
 description = "Convert JSON schemas into Nickel contracts."
 readme = "README.md"
 homepage = "https://github.com/mtoohey31/json-schema-to-nickel"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Matthew Toohey
+   Copyright 2023 Matthew Toohey and Modus Create LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Matthew Toohey
+Copyright (c) 2023 Matthew Toohey and Modus Create LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This project started from an existing attempt at implementing a JSON Schema to Nickel converter, but is now maintained  independently by Tweag employee(s). This commit updates the copyright and author information, by appending the new information (while preserving the original!), as it seems to be customary on such collaborative open source projects (e.g. the Linux kernel), and after asking knowledgeable people about the situation.