### PR TITLE
Switch to fenix for rust tooling

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -128,6 +128,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1688538381,
+        "narHash": "sha256-CH4j882pozkEmzvOlnyflnla+BpzRL+DeOiGUz4aK2E=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "b95669bcfa88a372848fb9f5f24c1679e641e7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -557,9 +578,27 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "fenix": "fenix",
         "nickel": "nickel",
         "nixpkgs": "nixpkgs_2",
         "topiary": "topiary_2"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1688494220,
+        "narHash": "sha256-9rYDFNKgbSHis5k13pHLvXMMZLBrvKyu+xyzsArXAJw=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "e95644e279592ea36061633779a2648afeb9536f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "rust-overlay": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,10 @@
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     nickel = {
       url = "github:tweag/nickel";
@@ -31,7 +35,8 @@
     in
     forSystems SYSTEMS (system: pkgs:
       let
-        craneLib = inputs.crane.mkLib pkgs;
+        rust = inputs.fenix.packages.${system}.stable;
+        craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rust.toolchain;
 
         missingSysPkgs =
           if pkgs.stdenv.isDarwin then
@@ -92,12 +97,10 @@
 
         devShells.${system}.default = pkgs.mkShell {
           inputsFrom = lib.attrValues inputs.self.checks.${system};
-          packages = with pkgs; [
-            cargo-watch
+          packages = [
+            rust.rust-analyzer
             inputs.topiary.packages.${system}.default
             inputs.nickel.packages.${system}.default
-            rust-analyzer
-            rustfmt
           ];
         };
       });


### PR DESCRIPTION
The previous development shell's rust-analyzer produced errors inconsistent with rustc's errors. This change makes sure to keep the tooling in sync.