### PR TITLE
Use static access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 [[package]]
 name = "nickel-lang-core"
 version = "0.1.0"
-source = "git+https://github.com/tweag/nickel?rev=refs/pull/1438/head#233d7694741405c9f9ef3a2c992c0d59fb476b57"
+source = "git+https://github.com/tweag/nickel?rev=refs/heads/master#c6e98d849e10d38fcc0d15f14809aae36fafa63f"
 dependencies = [
  "clap",
  "codespan",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 [[package]]
 name = "nickel-lang-core"
 version = "0.1.0"
-source = "git+https://github.com/tweag/nickel?rev=ec3b9c4a35bced37d321a01636b80b4f91533924#ec3b9c4a35bced37d321a01636b80b4f91533924"
+source = "git+https://github.com/tweag/nickel?rev=refs/pull/1438/head#233d7694741405c9f9ef3a2c992c0d59fb476b57"
 dependencies = [
  "clap",
  "codespan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 clap = { version = "^4.3", features = ["derive"] }
-nickel-lang-core = { git = "https://github.com/tweag/nickel", rev = "refs/pull/1438/head", default-features = false }
+nickel-lang-core = { git = "https://github.com/tweag/nickel", rev = "refs/heads/master", default-features = false }
 pretty = "^0.11"
 schemars = "^0.8"
 serde_json = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 clap = { version = "^4.3", features = ["derive"] }
-nickel-lang-core = { git = "https://github.com/tweag/nickel", rev = "ec3b9c4a35bced37d321a01636b80b4f91533924", default-features = false }
+nickel-lang-core = { git = "https://github.com/tweag/nickel", rev = "refs/pull/1438/head", default-features = false }
 pretty = "^0.11"
 schemars = "^0.8"
 serde_json = "^1.0"

--- a/lib/records.ncl
+++ b/lib/records.ncl
@@ -73,7 +73,7 @@
                   else
                     let result = value x."%{field}" in
                     if !result.success then
-                      { success = false, error = m%"field "%{field}" didn't validate: %{result.error}"%, checked : { _ : Bool } = {} }
+                      { success = false, error = m%%"field "%{field}" didn't validate: %{result.error}"%%, checked : { _ : Bool } = {} }
                     else
                       { success = acc.success, error = acc.error, checked = std.record.insert field true acc.checked }
               )
@@ -108,7 +108,7 @@
                         fun { field, value } acc =>
                           let result = pred value in
                           if !result.success then
-                            { success = false, error = m%"field "%{field}" didn't validate: %{result.error}"%, checked : { _ : Bool } = {} }
+                            { success = false, error = m%%"field "%{field}" didn't validate: %{result.error}"%%, checked : { _ : Bool } = {} }
                           else
                             { success = acc.success, error = acc.error, checked = std.record.insert field true acc.checked }
                       )
@@ -158,7 +158,7 @@
                   fun { field, value } acc =>
                     let result = additionalProperties value in
                     if !result.success then
-                      { success = false, error = m%"field "%{field}" didn't validate: %{result.error}"% }
+                      { success = false, error = m%%"field "%{field}" didn't validate: %{result.error}"%% }
                     else
                       acc
                 )

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -33,7 +33,7 @@ use nickel_lang_core::{
     term::{
         make,
         record::{Field, FieldMetadata, RecordAttrs, RecordData},
-        LabeledType, RichTerm, Term, TypeAnnotation, UnaryOp,
+        LabeledType, RichTerm, Term, TypeAnnotation,
     },
     types::{TypeF, Types},
 };
@@ -53,7 +53,7 @@ use crate::{definitions::References, predicates::schema_to_predicate};
 fn type_to_contract(x: InstanceType) -> RichTerm {
     match x {
         InstanceType::Null => contract_from_predicate(mk_app!(
-            make::var("predicates.isType"),
+            make::static_access_("predicates", ["isType"]),
             Term::Enum("Null".into())
         )),
         InstanceType::Boolean => make::var("Bool"),
@@ -65,7 +65,7 @@ fn type_to_contract(x: InstanceType) -> RichTerm {
         InstanceType::Array => mk_app!(make::var("Array"), make::var("Dyn")),
         InstanceType::Number => make::var("Number"),
         InstanceType::String => make::var("String"),
-        InstanceType::Integer => make::var("std.number.Integer"),
+        InstanceType::Integer => make::static_access_("std", ["number", "Integer"]),
     }
 }
 
@@ -196,7 +196,11 @@ fn generate_record_contract(
     let fields = properties.iter().map(|(name, schema)| {
         let contracts = match schema {
             Schema::Bool(false) => vec![LabeledType {
-                types: TypeF::Flat(contract_from_predicate(make::var("predicates.never"))).into(),
+                types: TypeF::Flat(contract_from_predicate(make::static_access_(
+                    "predicates",
+                    ["never"],
+                )))
+                .into(),
                 label: Label::dummy(),
             }],
             Schema::Bool(true) => vec![],
@@ -246,10 +250,7 @@ fn generate_record_contract(
 /// assertion `term | Contract`.
 pub fn contract_from_predicate(predicate: RichTerm) -> RichTerm {
     mk_app!(
-        make::op1(
-            UnaryOp::StaticAccess("contract_from_predicate".into()),
-            make::var("predicates")
-        ),
+        make::static_access_("predicates", ["contract_from_predicate"]),
         predicate
     )
 }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -39,7 +39,7 @@ use nickel_lang_core::{
 };
 use schemars::schema::{InstanceType, ObjectValidation, Schema, SchemaObject, SingleOrVec};
 
-use crate::{definitions::References, predicates::schema_to_predicate};
+use crate::{definitions::References, predicates::schema_to_predicate, utils::static_access_};
 
 /// Convert an [`InstanceType`] into a Nickel [`RichTerm`]. Currently,
 /// `RichTerm` doesn't include a variant for embedding Nickel types into terms.
@@ -53,7 +53,7 @@ use crate::{definitions::References, predicates::schema_to_predicate};
 fn type_to_contract(x: InstanceType) -> RichTerm {
     match x {
         InstanceType::Null => contract_from_predicate(mk_app!(
-            make::static_access_("predicates", ["isType"]),
+            static_access_("predicates", ["isType"]),
             Term::Enum("Null".into())
         )),
         InstanceType::Boolean => make::var("Bool"),
@@ -65,7 +65,7 @@ fn type_to_contract(x: InstanceType) -> RichTerm {
         InstanceType::Array => mk_app!(make::var("Array"), make::var("Dyn")),
         InstanceType::Number => make::var("Number"),
         InstanceType::String => make::var("String"),
-        InstanceType::Integer => make::static_access_("std", ["number", "Integer"]),
+        InstanceType::Integer => static_access_("std", ["number", "Integer"]),
     }
 }
 
@@ -196,7 +196,7 @@ fn generate_record_contract(
     let fields = properties.iter().map(|(name, schema)| {
         let contracts = match schema {
             Schema::Bool(false) => vec![LabeledType {
-                types: TypeF::Flat(contract_from_predicate(make::static_access_(
+                types: TypeF::Flat(contract_from_predicate(static_access_(
                     "predicates",
                     ["never"],
                 )))
@@ -250,7 +250,7 @@ fn generate_record_contract(
 /// assertion `term | Contract`.
 pub fn contract_from_predicate(predicate: RichTerm) -> RichTerm {
     mk_app!(
-        make::static_access_("predicates", ["contract_from_predicate"]),
+        static_access_("predicates", ["contract_from_predicate"]),
         predicate
     )
 }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -39,7 +39,7 @@ use nickel_lang_core::{
 };
 use schemars::schema::{InstanceType, ObjectValidation, Schema, SchemaObject, SingleOrVec};
 
-use crate::{definitions::References, predicates::schema_to_predicate, utils::static_access_};
+use crate::{definitions::References, predicates::schema_to_predicate, utils::static_access};
 
 /// Convert an [`InstanceType`] into a Nickel [`RichTerm`]. Currently,
 /// `RichTerm` doesn't include a variant for embedding Nickel types into terms.
@@ -53,7 +53,7 @@ use crate::{definitions::References, predicates::schema_to_predicate, utils::sta
 fn type_to_contract(x: InstanceType) -> RichTerm {
     match x {
         InstanceType::Null => contract_from_predicate(mk_app!(
-            static_access_("predicates", ["isType"]),
+            static_access("predicates", ["isType"]),
             Term::Enum("Null".into())
         )),
         InstanceType::Boolean => make::var("Bool"),
@@ -65,7 +65,7 @@ fn type_to_contract(x: InstanceType) -> RichTerm {
         InstanceType::Array => mk_app!(make::var("Array"), make::var("Dyn")),
         InstanceType::Number => make::var("Number"),
         InstanceType::String => make::var("String"),
-        InstanceType::Integer => static_access_("std", ["number", "Integer"]),
+        InstanceType::Integer => static_access("std", ["number", "Integer"]),
     }
 }
 
@@ -196,7 +196,7 @@ fn generate_record_contract(
     let fields = properties.iter().map(|(name, schema)| {
         let contracts = match schema {
             Schema::Bool(false) => vec![LabeledType {
-                types: TypeF::Flat(contract_from_predicate(static_access_(
+                types: TypeF::Flat(contract_from_predicate(static_access(
                     "predicates",
                     ["never"],
                 )))
@@ -250,7 +250,7 @@ fn generate_record_contract(
 /// assertion `term | Contract`.
 pub fn contract_from_predicate(predicate: RichTerm) -> RichTerm {
     mk_app!(
-        static_access_("predicates", ["contract_from_predicate"]),
+        static_access("predicates", ["contract_from_predicate"]),
         predicate
     )
 }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -22,7 +22,7 @@ use schemars::schema::Schema;
 use crate::{
     contracts::{contract_from_predicate, schema_to_contract},
     predicates::schema_to_predicate,
-    utils::static_access_,
+    utils::static_access,
 };
 
 /// The predicate and contract generated for a schema.
@@ -67,8 +67,8 @@ impl References {
                     (
                         String::from(id),
                         Access {
-                            contract: static_access_("definitions", ["contract", id]),
-                            predicate: static_access_("definitions", ["predicate", id]),
+                            contract: static_access("definitions", ["contract", id]),
+                            predicate: static_access("definitions", ["predicate", id]),
                         },
                     )
                 })

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -15,13 +15,14 @@ use std::collections::{BTreeMap, HashMap};
 
 use nickel_lang_core::{
     identifier::Ident,
-    term::{make, record::RecordData, LetAttrs, RichTerm, Term},
+    term::{record::RecordData, LetAttrs, RichTerm, Term},
 };
 use schemars::schema::Schema;
 
 use crate::{
     contracts::{contract_from_predicate, schema_to_contract},
     predicates::schema_to_predicate,
+    utils::static_access_,
 };
 
 /// The predicate and contract generated for a schema.
@@ -66,8 +67,8 @@ impl References {
                     (
                         String::from(id),
                         Access {
-                            contract: make::static_access_("definitions", ["contract", id]),
-                            predicate: make::static_access_("definitions", ["predicate", id]),
+                            contract: static_access_("definitions", ["contract", id]),
+                            predicate: static_access_("definitions", ["predicate", id]),
                         },
                     )
                 })

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -15,7 +15,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use nickel_lang_core::{
     identifier::Ident,
-    term::{make, record::RecordData, LetAttrs, RichTerm, Term, UnaryOp},
+    term::{make, record::RecordData, LetAttrs, RichTerm, Term},
 };
 use schemars::schema::Schema;
 
@@ -62,24 +62,12 @@ impl References {
             fields
                 .into_iter()
                 .map(|n| {
-                    let id = Ident::from(n.as_ref());
+                    let id = n.as_ref();
                     (
-                        String::from(n.as_ref()),
+                        String::from(id),
                         Access {
-                            contract: make::op1(
-                                UnaryOp::StaticAccess(id),
-                                make::op1(
-                                    UnaryOp::StaticAccess("contract".into()),
-                                    make::var("definitions"),
-                                ),
-                            ),
-                            predicate: make::op1(
-                                UnaryOp::StaticAccess(id),
-                                make::op1(
-                                    UnaryOp::StaticAccess("predicate".into()),
-                                    make::var("definitions"),
-                                ),
-                            ),
+                            contract: make::static_access_("definitions", ["contract", id]),
+                            predicate: make::static_access_("definitions", ["predicate", id]),
                         },
                     )
                 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod contracts;
 pub mod definitions;
 pub mod predicates;
+pub(crate) mod utils;
 
 use contracts::{contract_from_predicate, schema_object_to_contract};
 use definitions::Environment;

--- a/src/predicates.rs
+++ b/src/predicates.rs
@@ -15,7 +15,7 @@ use crate::definitions::References;
 
 fn or_always(env: &References, s: Option<&Schema>) -> RichTerm {
     s.map(|s| schema_to_predicate(env, s))
-        .unwrap_or(make::var("predicates.always"))
+        .unwrap_or(make::static_access_("predicates", ["always"]))
 }
 
 fn type_to_predicate(x: InstanceType) -> RichTerm {
@@ -28,14 +28,14 @@ fn type_to_predicate(x: InstanceType) -> RichTerm {
         InstanceType::String => Term::Enum("String".into()),
         InstanceType::Integer => Term::Enum("Integer".into()),
     };
-    mk_app!(make::var("predicates.isType"), type_tag)
+    mk_app!(make::static_access_("predicates", ["isType"]), type_tag)
 }
 
 fn types_to_predicate(x: &SingleOrVec<InstanceType>) -> RichTerm {
     match x {
         SingleOrVec::Single(t) => type_to_predicate(**t),
         SingleOrVec::Vec(ts) => mk_app!(
-            make::var("predicates.anyOf"),
+            make::static_access_("predicates", ["anyOf"]),
             Term::Array(
                 Array::new(ts.iter().map(|t| type_to_predicate(*t)).collect()),
                 Default::default()
@@ -46,7 +46,7 @@ fn types_to_predicate(x: &SingleOrVec<InstanceType>) -> RichTerm {
 
 fn enum_to_predicate(vs: &[Value]) -> RichTerm {
     mk_app!(
-        make::var("predicates.enum"),
+        make::static_access_("predicates", ["enum"]),
         Term::Array(
             Array::new(
                 vs.iter()
@@ -60,7 +60,7 @@ fn enum_to_predicate(vs: &[Value]) -> RichTerm {
 
 fn const_to_predicate(v: &Value) -> RichTerm {
     Term::App(
-        make::var("predicates.const"),
+        make::static_access_("predicates", ["const"]),
         serde_json::from_value(v.clone()).unwrap(),
     )
     .into()
@@ -69,10 +69,10 @@ fn const_to_predicate(v: &Value) -> RichTerm {
 fn mk_all_of(schemas: impl IntoIterator<Item = RichTerm>) -> RichTerm {
     let schemas: Vec<_> = schemas.into_iter().collect();
     match schemas.as_slice() {
-        [] => make::var("predicates.always"),
+        [] => make::static_access_("predicates", ["always"]),
         [t] => t.clone(),
         _ => mk_app!(
-            make::var("predicates.allOf"),
+            make::static_access_("predicates", ["allOf"]),
             Term::Array(Array::from_iter(schemas), Default::default())
         ),
     }
@@ -81,10 +81,10 @@ fn mk_all_of(schemas: impl IntoIterator<Item = RichTerm>) -> RichTerm {
 fn mk_any_of(schemas: impl IntoIterator<Item = RichTerm>) -> RichTerm {
     let schemas: Vec<_> = schemas.into_iter().collect();
     match schemas.as_slice() {
-        [] => make::var("predicates.always"),
+        [] => make::static_access_("predicates", ["always"]),
         [t] => t.clone(),
         _ => mk_app!(
-            make::var("predicates.anyOf"),
+            make::static_access_("predicates", ["anyOf"]),
             Term::Array(Array::from_iter(schemas), Default::default())
         ),
     }
@@ -118,7 +118,7 @@ fn subschema_predicates(
         .as_deref()
         .map(|schemas| {
             mk_app!(
-                make::var("predicates.oneOf"),
+                make::static_access_("predicates", ["oneOf"]),
                 Term::Array(
                     Array::new(
                         schemas
@@ -134,14 +134,19 @@ fn subschema_predicates(
 
     let not = not
         .as_deref()
-        .map(|s| mk_app!(make::var("predicates.not"), schema_to_predicate(env, s)))
+        .map(|s| {
+            mk_app!(
+                make::static_access_("predicates", ["not"]),
+                schema_to_predicate(env, s)
+            )
+        })
         .into_iter();
 
     let ite = if_schema
         .as_deref()
         .map(move |if_schema| {
             mk_app!(
-                make::var("predicates.ifThenElse"),
+                make::static_access_("predicates", ["ifThenElse"]),
                 schema_to_predicate(env, if_schema),
                 or_always(env, then_schema.as_deref()),
                 or_always(env, else_schema.as_deref())
@@ -164,7 +169,7 @@ fn number_predicates(nv: &NumberValidation) -> impl Iterator<Item = RichTerm> {
     fn predicate(s: &str) -> impl '_ + FnOnce(f64) -> RichTerm {
         move |n| {
             mk_app!(
-                make::var(format!("predicates.numbers.{s}")),
+                make::static_access_("predicates", ["numbers", s]),
                 Term::Num(Number::try_from_float_simplest(n).unwrap())
             )
         }
@@ -197,7 +202,7 @@ fn string_predicates(sv: &StringValidation) -> impl Iterator<Item = RichTerm> {
     let max_length = max_length
         .map(|n| {
             mk_app!(
-                make::var("predicates.strings.maxLength"),
+                make::static_access_("predicates", ["strings", "maxLength"]),
                 Term::Num(n.into())
             )
         })
@@ -206,7 +211,7 @@ fn string_predicates(sv: &StringValidation) -> impl Iterator<Item = RichTerm> {
     let min_length = min_length
         .map(|n| {
             mk_app!(
-                make::var("predicates.strings.minLength"),
+                make::static_access_("predicates", ["strings", "minLength"]),
                 Term::Num(n.into())
             )
         })
@@ -214,7 +219,12 @@ fn string_predicates(sv: &StringValidation) -> impl Iterator<Item = RichTerm> {
 
     let pattern = pattern
         .as_deref()
-        .map(|s| mk_app!(make::var("predicates.strings.pattern"), make::string(s)))
+        .map(|s| {
+            mk_app!(
+                make::static_access_("predicates", ["strings", "pattern"]),
+                make::string(s)
+            )
+        })
         .into_iter();
 
     max_length.chain(min_length).chain(pattern)
@@ -233,13 +243,13 @@ fn array_predicates(env: &References, av: &ArrayValidation) -> impl Iterator<Ite
     let items = match items {
         None => vec![],
         Some(SingleOrVec::Single(s)) => vec![mk_app!(
-            make::var("predicates.arrays.arrayOf"),
+            make::static_access_("predicates", ["arrays", "arrayOf"]),
             schema_to_predicate(env, s)
         )],
         Some(SingleOrVec::Vec(schemas)) => {
             let len = schemas.len();
             [mk_app!(
-                make::var("predicates.arrays.items"),
+                make::static_access_("predicates", ["arrays", "items"]),
                 Term::Array(
                     Array::new(
                         schemas
@@ -253,7 +263,7 @@ fn array_predicates(env: &References, av: &ArrayValidation) -> impl Iterator<Ite
             .into_iter()
             .chain(additional_items.as_deref().map(|s| {
                 mk_app!(
-                    make::var("predicates.arrays.additionalItems"),
+                    make::static_access_("predicates", ["arrays", "additionalItems"]),
                     schema_to_predicate(env, s),
                     Term::Num(len.into())
                 )
@@ -264,22 +274,37 @@ fn array_predicates(env: &References, av: &ArrayValidation) -> impl Iterator<Ite
     .into_iter();
 
     let max_items = max_items
-        .map(|n| mk_app!(make::var("predicates.arrays.maxItems"), Term::Num(n.into())))
+        .map(|n| {
+            mk_app!(
+                make::static_access_("predicates", ["arrays", "maxItems"]),
+                Term::Num(n.into())
+            )
+        })
         .into_iter();
 
     let min_items = min_items
-        .map(|n| mk_app!(make::var("predicates.arrays.minItems"), Term::Num(n.into())))
+        .map(|n| {
+            mk_app!(
+                make::static_access_("predicates", ["arrays", "minItems"]),
+                Term::Num(n.into())
+            )
+        })
         .into_iter();
 
     let unique_items = unique_items
-        .and_then(|unique| unique.then_some(make::var("predicates.arrays.uniqueItems")))
+        .and_then(|unique| {
+            unique.then_some(make::static_access_(
+                "predicates",
+                ["arrays", "uniqueItems"],
+            ))
+        })
         .into_iter();
 
     let contains = contains
         .as_deref()
         .map(|s| {
             mk_app!(
-                make::var("predicates.arrays.contains"),
+                make::static_access_("predicates", ["arrays", "contains"]),
                 schema_to_predicate(env, s)
             )
         })
@@ -306,7 +331,7 @@ fn object_predicates(env: &References, ov: &ObjectValidation) -> impl Iterator<I
     let max_properties = max_properties
         .map(|n| {
             mk_app!(
-                make::var("predicates.records.maxProperties"),
+                make::static_access_("predicates", ["records", "maxProperties"]),
                 Term::Num(n.into())
             )
         })
@@ -315,7 +340,7 @@ fn object_predicates(env: &References, ov: &ObjectValidation) -> impl Iterator<I
     let min_properties = min_properties
         .map(|n| {
             mk_app!(
-                make::var("predicates.records.minProperties"),
+                make::static_access_("predicates", ["records", "minProperties"]),
                 Term::Num(n.into())
             )
         })
@@ -325,7 +350,7 @@ fn object_predicates(env: &References, ov: &ObjectValidation) -> impl Iterator<I
         .as_deref()
         .map(|s| {
             mk_app!(
-                make::var("predicates.records.propertyNames"),
+                make::static_access_("predicates", ["records", "propertyNames"]),
                 schema_to_predicate(env, s)
             )
         })
@@ -336,7 +361,7 @@ fn object_predicates(env: &References, ov: &ObjectValidation) -> impl Iterator<I
             None
         } else {
             Some(mk_app!(
-                make::var("predicates.records.required"),
+                make::static_access_("predicates", ["records", "required"]),
                 Term::Array(
                     Array::new(required.iter().map(make::string).collect()),
                     Default::default()
@@ -347,7 +372,7 @@ fn object_predicates(env: &References, ov: &ObjectValidation) -> impl Iterator<I
     .into_iter();
 
     let record = [mk_app!(
-        make::var("predicates.records.record"),
+        make::static_access_("predicates", ["records", "record"]),
         Term::Record(RecordData::with_field_values(
             properties
                 .iter()
@@ -384,7 +409,7 @@ fn dependencies(
         .and_then(|v| v.as_object())
         .map(|deps| {
             mk_app!(
-                make::var("predicates.records.dependencies"),
+                make::static_access_("predicates", ["records", "dependencies"]),
                 Term::Record(RecordData::with_field_values(
                     deps.into_iter()
                         .map(|(key, value)| (
@@ -449,8 +474,8 @@ pub fn schema_object_to_predicate(env: &References, o: &SchemaObject) -> RichTer
 
 pub fn schema_to_predicate(env: &References, schema: &Schema) -> RichTerm {
     match schema {
-        Schema::Bool(true) => make::var("predicates.always"),
-        Schema::Bool(false) => make::var("predicates.never"),
+        Schema::Bool(true) => make::static_access_("predicates", ["always"]),
+        Schema::Bool(false) => make::static_access_("predicates", ["never"]),
         Schema::Object(o) => schema_object_to_predicate(env, o),
     }
 }

--- a/src/predicates.rs
+++ b/src/predicates.rs
@@ -11,11 +11,11 @@ use schemars::schema::{
 };
 use serde_json::Value;
 
-use crate::{definitions::References, utils::static_access_};
+use crate::{definitions::References, utils::static_access};
 
 fn or_always(env: &References, s: Option<&Schema>) -> RichTerm {
     s.map(|s| schema_to_predicate(env, s))
-        .unwrap_or(static_access_("predicates", ["always"]))
+        .unwrap_or(static_access("predicates", ["always"]))
 }
 
 fn type_to_predicate(x: InstanceType) -> RichTerm {
@@ -28,14 +28,14 @@ fn type_to_predicate(x: InstanceType) -> RichTerm {
         InstanceType::String => Term::Enum("String".into()),
         InstanceType::Integer => Term::Enum("Integer".into()),
     };
-    mk_app!(static_access_("predicates", ["isType"]), type_tag)
+    mk_app!(static_access("predicates", ["isType"]), type_tag)
 }
 
 fn types_to_predicate(x: &SingleOrVec<InstanceType>) -> RichTerm {
     match x {
         SingleOrVec::Single(t) => type_to_predicate(**t),
         SingleOrVec::Vec(ts) => mk_app!(
-            static_access_("predicates", ["anyOf"]),
+            static_access("predicates", ["anyOf"]),
             Term::Array(
                 Array::new(ts.iter().map(|t| type_to_predicate(*t)).collect()),
                 Default::default()
@@ -46,7 +46,7 @@ fn types_to_predicate(x: &SingleOrVec<InstanceType>) -> RichTerm {
 
 fn enum_to_predicate(vs: &[Value]) -> RichTerm {
     mk_app!(
-        static_access_("predicates", ["enum"]),
+        static_access("predicates", ["enum"]),
         Term::Array(
             Array::new(
                 vs.iter()
@@ -60,7 +60,7 @@ fn enum_to_predicate(vs: &[Value]) -> RichTerm {
 
 fn const_to_predicate(v: &Value) -> RichTerm {
     Term::App(
-        static_access_("predicates", ["const"]),
+        static_access("predicates", ["const"]),
         serde_json::from_value(v.clone()).unwrap(),
     )
     .into()
@@ -69,10 +69,10 @@ fn const_to_predicate(v: &Value) -> RichTerm {
 fn mk_all_of(schemas: impl IntoIterator<Item = RichTerm>) -> RichTerm {
     let schemas: Vec<_> = schemas.into_iter().collect();
     match schemas.as_slice() {
-        [] => static_access_("predicates", ["always"]),
+        [] => static_access("predicates", ["always"]),
         [t] => t.clone(),
         _ => mk_app!(
-            static_access_("predicates", ["allOf"]),
+            static_access("predicates", ["allOf"]),
             Term::Array(Array::from_iter(schemas), Default::default())
         ),
     }
@@ -81,10 +81,10 @@ fn mk_all_of(schemas: impl IntoIterator<Item = RichTerm>) -> RichTerm {
 fn mk_any_of(schemas: impl IntoIterator<Item = RichTerm>) -> RichTerm {
     let schemas: Vec<_> = schemas.into_iter().collect();
     match schemas.as_slice() {
-        [] => static_access_("predicates", ["always"]),
+        [] => static_access("predicates", ["always"]),
         [t] => t.clone(),
         _ => mk_app!(
-            static_access_("predicates", ["anyOf"]),
+            static_access("predicates", ["anyOf"]),
             Term::Array(Array::from_iter(schemas), Default::default())
         ),
     }
@@ -118,7 +118,7 @@ fn subschema_predicates(
         .as_deref()
         .map(|schemas| {
             mk_app!(
-                static_access_("predicates", ["oneOf"]),
+                static_access("predicates", ["oneOf"]),
                 Term::Array(
                     Array::new(
                         schemas
@@ -136,7 +136,7 @@ fn subschema_predicates(
         .as_deref()
         .map(|s| {
             mk_app!(
-                static_access_("predicates", ["not"]),
+                static_access("predicates", ["not"]),
                 schema_to_predicate(env, s)
             )
         })
@@ -146,7 +146,7 @@ fn subschema_predicates(
         .as_deref()
         .map(move |if_schema| {
             mk_app!(
-                static_access_("predicates", ["ifThenElse"]),
+                static_access("predicates", ["ifThenElse"]),
                 schema_to_predicate(env, if_schema),
                 or_always(env, then_schema.as_deref()),
                 or_always(env, else_schema.as_deref())
@@ -169,7 +169,7 @@ fn number_predicates(nv: &NumberValidation) -> impl Iterator<Item = RichTerm> {
     fn predicate(s: &str) -> impl '_ + FnOnce(f64) -> RichTerm {
         move |n| {
             mk_app!(
-                static_access_("predicates", ["numbers", s]),
+                static_access("predicates", ["numbers", s]),
                 Term::Num(Number::try_from_float_simplest(n).unwrap())
             )
         }
@@ -202,7 +202,7 @@ fn string_predicates(sv: &StringValidation) -> impl Iterator<Item = RichTerm> {
     let max_length = max_length
         .map(|n| {
             mk_app!(
-                static_access_("predicates", ["strings", "maxLength"]),
+                static_access("predicates", ["strings", "maxLength"]),
                 Term::Num(n.into())
             )
         })
@@ -211,7 +211,7 @@ fn string_predicates(sv: &StringValidation) -> impl Iterator<Item = RichTerm> {
     let min_length = min_length
         .map(|n| {
             mk_app!(
-                static_access_("predicates", ["strings", "minLength"]),
+                static_access("predicates", ["strings", "minLength"]),
                 Term::Num(n.into())
             )
         })
@@ -221,7 +221,7 @@ fn string_predicates(sv: &StringValidation) -> impl Iterator<Item = RichTerm> {
         .as_deref()
         .map(|s| {
             mk_app!(
-                static_access_("predicates", ["strings", "pattern"]),
+                static_access("predicates", ["strings", "pattern"]),
                 make::string(s)
             )
         })
@@ -243,13 +243,13 @@ fn array_predicates(env: &References, av: &ArrayValidation) -> impl Iterator<Ite
     let items = match items {
         None => vec![],
         Some(SingleOrVec::Single(s)) => vec![mk_app!(
-            static_access_("predicates", ["arrays", "arrayOf"]),
+            static_access("predicates", ["arrays", "arrayOf"]),
             schema_to_predicate(env, s)
         )],
         Some(SingleOrVec::Vec(schemas)) => {
             let len = schemas.len();
             [mk_app!(
-                static_access_("predicates", ["arrays", "items"]),
+                static_access("predicates", ["arrays", "items"]),
                 Term::Array(
                     Array::new(
                         schemas
@@ -263,7 +263,7 @@ fn array_predicates(env: &References, av: &ArrayValidation) -> impl Iterator<Ite
             .into_iter()
             .chain(additional_items.as_deref().map(|s| {
                 mk_app!(
-                    static_access_("predicates", ["arrays", "additionalItems"]),
+                    static_access("predicates", ["arrays", "additionalItems"]),
                     schema_to_predicate(env, s),
                     Term::Num(len.into())
                 )
@@ -276,7 +276,7 @@ fn array_predicates(env: &References, av: &ArrayValidation) -> impl Iterator<Ite
     let max_items = max_items
         .map(|n| {
             mk_app!(
-                static_access_("predicates", ["arrays", "maxItems"]),
+                static_access("predicates", ["arrays", "maxItems"]),
                 Term::Num(n.into())
             )
         })
@@ -285,23 +285,21 @@ fn array_predicates(env: &References, av: &ArrayValidation) -> impl Iterator<Ite
     let min_items = min_items
         .map(|n| {
             mk_app!(
-                static_access_("predicates", ["arrays", "minItems"]),
+                static_access("predicates", ["arrays", "minItems"]),
                 Term::Num(n.into())
             )
         })
         .into_iter();
 
     let unique_items = unique_items
-        .and_then(|unique| {
-            unique.then_some(static_access_("predicates", ["arrays", "uniqueItems"]))
-        })
+        .and_then(|unique| unique.then_some(static_access("predicates", ["arrays", "uniqueItems"])))
         .into_iter();
 
     let contains = contains
         .as_deref()
         .map(|s| {
             mk_app!(
-                static_access_("predicates", ["arrays", "contains"]),
+                static_access("predicates", ["arrays", "contains"]),
                 schema_to_predicate(env, s)
             )
         })
@@ -328,7 +326,7 @@ fn object_predicates(env: &References, ov: &ObjectValidation) -> impl Iterator<I
     let max_properties = max_properties
         .map(|n| {
             mk_app!(
-                static_access_("predicates", ["records", "maxProperties"]),
+                static_access("predicates", ["records", "maxProperties"]),
                 Term::Num(n.into())
             )
         })
@@ -337,7 +335,7 @@ fn object_predicates(env: &References, ov: &ObjectValidation) -> impl Iterator<I
     let min_properties = min_properties
         .map(|n| {
             mk_app!(
-                static_access_("predicates", ["records", "minProperties"]),
+                static_access("predicates", ["records", "minProperties"]),
                 Term::Num(n.into())
             )
         })
@@ -347,7 +345,7 @@ fn object_predicates(env: &References, ov: &ObjectValidation) -> impl Iterator<I
         .as_deref()
         .map(|s| {
             mk_app!(
-                static_access_("predicates", ["records", "propertyNames"]),
+                static_access("predicates", ["records", "propertyNames"]),
                 schema_to_predicate(env, s)
             )
         })
@@ -358,7 +356,7 @@ fn object_predicates(env: &References, ov: &ObjectValidation) -> impl Iterator<I
             None
         } else {
             Some(mk_app!(
-                static_access_("predicates", ["records", "required"]),
+                static_access("predicates", ["records", "required"]),
                 Term::Array(
                     Array::new(required.iter().map(make::string).collect()),
                     Default::default()
@@ -369,7 +367,7 @@ fn object_predicates(env: &References, ov: &ObjectValidation) -> impl Iterator<I
     .into_iter();
 
     let record = [mk_app!(
-        static_access_("predicates", ["records", "record"]),
+        static_access("predicates", ["records", "record"]),
         Term::Record(RecordData::with_field_values(
             properties
                 .iter()
@@ -406,7 +404,7 @@ fn dependencies(
         .and_then(|v| v.as_object())
         .map(|deps| {
             mk_app!(
-                static_access_("predicates", ["records", "dependencies"]),
+                static_access("predicates", ["records", "dependencies"]),
                 Term::Record(RecordData::with_field_values(
                     deps.into_iter()
                         .map(|(key, value)| (
@@ -471,8 +469,8 @@ pub fn schema_object_to_predicate(env: &References, o: &SchemaObject) -> RichTer
 
 pub fn schema_to_predicate(env: &References, schema: &Schema) -> RichTerm {
     match schema {
-        Schema::Bool(true) => static_access_("predicates", ["always"]),
-        Schema::Bool(false) => static_access_("predicates", ["never"]),
+        Schema::Bool(true) => static_access("predicates", ["always"]),
+        Schema::Bool(false) => static_access("predicates", ["never"]),
         Schema::Object(o) => schema_object_to_predicate(env, o),
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,7 @@ use nickel_lang_core::{
     term::{make, RichTerm},
 };
 
-pub fn static_access_<I, S>(record: S, fields: I) -> RichTerm
+pub fn static_access<I, S>(record: S, fields: I) -> RichTerm
 where
     I: IntoIterator<Item = S>,
     I::IntoIter: DoubleEndedIterator,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,13 @@
+use nickel_lang_core::{
+    identifier::Ident,
+    term::{make, RichTerm},
+};
+
+pub fn static_access_<I, S>(record: S, fields: I) -> RichTerm
+where
+    I: IntoIterator<Item = S>,
+    I::IntoIter: DoubleEndedIterator,
+    S: Into<Ident>,
+{
+    make::static_access(make::var(record), fields)
+}


### PR DESCRIPTION
The Nickel pretty printer doesn't try to quote invalid variable names, since doing so wouldn't result in valid Nickel anyway. Previously we abused this behavior to make constructing record accesses like `predicates.records.record` less of a hassle. This change rewrites these occurrences into uses of `make::static_access` which is more principled and only slightly more typing.

Relatedly, this PR updates the `nickel-lang-core` dependency to the latest HEAD and fixes invalid string interpolation syntax exposed by https://github.com/tweag/nickel/pull/1435.