### PR TITLE
Remove the separate reference access environment

### DIFF
--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -40,60 +40,23 @@ pub struct Access {
     pub contract: RichTerm,
 }
 
-/// A newtype around [`HashMap`] for keeping track of the Nickel code for
-/// referencing top level schema definitions.
-#[derive(Clone, Default)]
-pub struct References(HashMap<String, Access>);
-
 /// An environment of top level schema definitions and their conversions into
 /// Nickel predicates and contracts.
 #[derive(Clone, Default)]
-pub struct Environment {
-    accesses: References,
-    terms: HashMap<String, Terms>,
+pub struct Environment(HashMap<String, Terms>);
+
+pub fn access(name: impl AsRef<str>) -> Access {
+    Access {
+        contract: static_access("definitions", ["contract", name.as_ref()]),
+        predicate: static_access("definitions", ["predicate", name.as_ref()]),
+    }
 }
 
-impl References {
-    fn with_fields<'a, F, I>(fields: F) -> Self
-    where
-        F: 'a + IntoIterator<Item = I>,
-        I: 'a + AsRef<str>,
-    {
-        Self(
-            fields
-                .into_iter()
-                .map(|n| {
-                    let id = n.as_ref();
-                    (
-                        String::from(id),
-                        Access {
-                            contract: static_access("definitions", ["contract", id]),
-                            predicate: static_access("definitions", ["predicate", id]),
-                        },
-                    )
-                })
-                .collect(),
-        )
-    }
-
-    pub fn get_predicate(&self, name: impl AsRef<str>) -> Option<RichTerm> {
-        self.0.get(name.as_ref()).map(|e| e.predicate.clone())
-    }
-
-    pub fn get_contract(&self, name: impl AsRef<str>) -> Option<RichTerm> {
-        self.0.get(name.as_ref()).map(|e| e.contract.clone())
-    }
-
-    pub fn access(&self, name: impl AsRef<str>) -> Option<&Access> {
-        self.0.get(name.as_ref())
-    }
-
-    pub fn reference(&self, reference: &str) -> &Access {
-        if let Some(remainder) = reference.strip_prefix("#/definitions/") {
-            self.access(remainder).unwrap()
-        } else {
-            unimplemented!()
-        }
+pub fn reference(reference: &str) -> Access {
+    if let Some(remainder) = reference.strip_prefix("#/definitions/") {
+        access(remainder)
+    } else {
+        unimplemented!()
     }
 }
 
@@ -108,12 +71,12 @@ impl Environment {
     /// tracked in the environment to actually work.
     pub fn wrap(self, inner: RichTerm) -> RichTerm {
         let contracts = self
-            .terms
+            .0
             .iter()
             .map(|(k, v)| (Ident::from(k), v.contract.clone()))
             .collect();
         let predicates = self
-            .terms
+            .0
             .into_iter()
             .map(|(k, v)| (Ident::from(k), v.predicate))
             .collect();
@@ -142,35 +105,24 @@ impl Environment {
         )
         .into()
     }
-
-    /// Extract just the Nickel field references
-    pub fn references(&self) -> &References {
-        &self.accesses
-    }
 }
 
 impl From<&BTreeMap<String, Schema>> for Environment {
     fn from(defs: &BTreeMap<String, Schema>) -> Self {
-        let accesses = References::with_fields(defs.keys());
         let terms = defs
             .iter()
             .map(|(name, schema)| {
-                let predicate = schema_to_predicate(&accesses, schema);
+                let predicate = schema_to_predicate(schema);
                 (
                     name.clone(),
                     Terms {
-                        contract: schema_to_contract(&accesses, schema).unwrap_or_else(|| {
-                            contract_from_predicate(
-                                accesses
-                                    .get_predicate(name)
-                                    .expect("accesses has the correct keys by construction"),
-                            )
-                        }),
+                        contract: schema_to_contract(schema)
+                            .unwrap_or_else(|| contract_from_predicate(access(name).predicate)),
                         predicate,
                     },
                 )
             })
             .collect();
-        Environment { accesses, terms }
+        Environment(terms)
     }
 }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -8,8 +8,8 @@
 //! references to top-level definitions in a schema.
 //!
 //! This module handles an [`Environment`] data structure that keeps track of
-//! top-level definitions in a JSON schema and their mapping to [`RichTerm`]s
-//! for accessing them.
+//! top-level definitions in a JSON schema and their translations into Nickel
+//! predicates and contracts.
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@ use schemars::schema::RootSchema;
 /// Otherwise, we fall back to generating a predicate.
 pub fn root_schema(root: &RootSchema) -> RichTerm {
     let env = Environment::from(&root.definitions);
-    if let Some(contract) = schema_object_to_contract(env.references(), &root.schema) {
+    if let Some(contract) = schema_object_to_contract(&root.schema) {
         wrap_contract(env, contract)
     } else {
-        let predicate = schema_object_to_predicate(env.references(), &root.schema);
+        let predicate = schema_object_to_predicate(&root.schema);
         wrap_predicate(env, predicate)
     }
 }

--- a/tests/json_schema_test_suite_test.rs
+++ b/tests/json_schema_test_suite_test.rs
@@ -37,10 +37,7 @@ fn translation_typecheck_test(
     } else {
         wrap_predicate(
             Environment::empty(),
-            schema_to_predicate(
-                &Default::default(),
-                &dbg!(serde_json::from_value(test_case.schema).unwrap()),
-            ),
+            schema_to_predicate(&dbg!(serde_json::from_value(test_case.schema).unwrap())),
         )
     };
 


### PR DESCRIPTION
The `References` type was originally introduced to track if particular top-level definitions in a JSON schema could be turned into a record contract or not. Accordingly there would be a `RichTerm` representing a reference to the record contract form and one for the predicate form. However, it turns out that we need to have access to both a predicate and a contract form for all definitions anyway. This makes the `References` environment superfluous since it's much easier to generate the appropiate `RichTerm`s on the fly.