### PR TITLE
As{Contract,Predicate,...} traits

### DIFF
--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -41,7 +41,7 @@ use schemars::schema::{InstanceType, ObjectValidation, Schema, SchemaObject, Sin
 
 use crate::{definitions, predicates::AsPredicate, utils::static_access};
 
-/// Convert to a Nickel [`RichtTerm`] representing a contract.
+/// Convert to a Nickel [`RichTerm`] representing a contract.
 pub trait AsContract {
     fn as_contract(&self) -> RichTerm;
 }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -41,19 +41,22 @@ use schemars::schema::{InstanceType, ObjectValidation, Schema, SchemaObject, Sin
 
 use crate::{definitions, predicates::AsPredicate, utils::static_access};
 
-// XXX: document
+/// Convert to a Nickel [`RichtTerm`] representing a contract.
 pub trait AsContract {
     fn as_contract(self) -> RichTerm;
 }
 
+/// Convert to a Nickel [`RichtTerm`] representing a contract, if possible.
 pub trait TryAsContract {
     fn try_as_contract(self) -> Option<RichTerm>;
 }
 
+/// Convert to a Nickel [`LabeledType`]
 pub trait AsLabeledType {
     fn as_labeled_type(self) -> LabeledType;
 }
 
+/// Convert to a Nickel [`LabeledType`], if possible.
 pub trait TryAsLabeledType {
     fn try_as_labeled_type(self) -> Option<LabeledType>;
 }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -39,7 +39,7 @@ use nickel_lang_core::{
 };
 use schemars::schema::{InstanceType, ObjectValidation, Schema, SchemaObject, SingleOrVec};
 
-use crate::{definitions, predicates::schema_to_predicate, utils::static_access};
+use crate::{definitions, predicates::AsPredicate, utils::static_access};
 
 // XXX: document
 pub trait AsContract {
@@ -269,7 +269,7 @@ fn generate_record_contract(
         } else if let Some(term) = schema.try_as_contract() {
             vec![term.as_labeled_type()]
         } else {
-            vec![contract_from_predicate(schema_to_predicate(schema)).as_labeled_type()]
+            vec![contract_from_predicate(schema.as_predicate()).as_labeled_type()]
         };
         (
             name.into(),

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -46,7 +46,7 @@ pub trait AsContract {
     fn as_contract(&self) -> RichTerm;
 }
 
-/// Convert to a Nickel [`RichtTerm`] representing a contract, if possible.
+/// Convert to a Nickel [`RichTerm`] representing a contract, if possible.
 pub trait TryAsContract {
     fn try_as_contract(&self) -> Option<RichTerm>;
 }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -39,26 +39,26 @@ use nickel_lang_core::{
 };
 use schemars::schema::{InstanceType, ObjectValidation, Schema, SchemaObject, SingleOrVec};
 
-use crate::{definitions, predicates::AsPredicate, utils::static_access};
+use crate::{definitions, predicates::IntoPredicate, utils::static_access};
 
 /// Convert to a Nickel [`RichtTerm`] representing a contract.
-pub trait AsContract {
-    fn as_contract(self) -> RichTerm;
+pub trait IntoContract {
+    fn into_contract(self) -> RichTerm;
 }
 
 /// Convert to a Nickel [`RichtTerm`] representing a contract, if possible.
-pub trait TryAsContract {
-    fn try_as_contract(self) -> Option<RichTerm>;
+pub trait TryIntoContract {
+    fn try_into_contract(self) -> Option<RichTerm>;
 }
 
 /// Convert to a Nickel [`LabeledType`]
-pub trait AsLabeledType {
-    fn as_labeled_type(self) -> LabeledType;
+pub trait IntoLabeledType {
+    fn into_labeled_type(self) -> LabeledType;
 }
 
 /// Convert to a Nickel [`LabeledType`], if possible.
-pub trait TryAsLabeledType {
-    fn try_as_labeled_type(self) -> Option<LabeledType>;
+pub trait TryIntoLabeledType {
+    fn try_into_labeled_type(self) -> Option<LabeledType>;
 }
 
 /// Convert an [`InstanceType`] into a Nickel [`RichTerm`]. We're in a bit of a
@@ -71,8 +71,8 @@ pub trait TryAsLabeledType {
 /// we passed this directly to Nickel as a `RichTerm`, it would be an error,
 /// but the pretty printer not understanding that builtin type names are not
 /// valid identifiers.
-impl AsContract for InstanceType {
-    fn as_contract(self) -> RichTerm {
+impl IntoContract for InstanceType {
+    fn into_contract(self) -> RichTerm {
         match self {
             InstanceType::Null => contract_from_predicate(mk_app!(
                 static_access("predicates", ["isType"]),
@@ -92,15 +92,15 @@ impl AsContract for InstanceType {
     }
 }
 
-impl AsLabeledType for InstanceType {
-    fn as_labeled_type(self) -> LabeledType {
+impl IntoLabeledType for InstanceType {
+    fn into_labeled_type(self) -> LabeledType {
         let types = match self {
             InstanceType::Boolean => TypeF::Bool.into(),
             InstanceType::Array => TypeF::Array(Box::new(Types::from(TypeF::Dyn))).into(),
             InstanceType::Number => TypeF::Number.into(),
             InstanceType::String => TypeF::String.into(),
             InstanceType::Null | InstanceType::Object | InstanceType::Integer => {
-                TypeF::Flat(self.as_contract()).into()
+                TypeF::Flat(self.into_contract()).into()
             }
         };
         LabeledType {
@@ -110,8 +110,8 @@ impl AsLabeledType for InstanceType {
     }
 }
 
-impl TryAsLabeledType for &SchemaObject {
-    fn try_as_labeled_type(self) -> Option<LabeledType> {
+impl TryIntoLabeledType for &SchemaObject {
+    fn try_into_labeled_type(self) -> Option<LabeledType> {
         match self {
             SchemaObject {
                 metadata: _,
@@ -127,23 +127,23 @@ impl TryAsLabeledType for &SchemaObject {
                 reference: None, /* TODO(vkleen): We should be able to relax this once we properly
                                   * track references */
                 extensions,
-            } if extensions.is_empty() => Some(instance_type.as_labeled_type()),
+            } if extensions.is_empty() => Some(instance_type.into_labeled_type()),
             _ => None,
         }
     }
 }
 
-impl TryAsLabeledType for &Schema {
-    fn try_as_labeled_type(self) -> Option<LabeledType> {
+impl TryIntoLabeledType for &Schema {
+    fn try_into_labeled_type(self) -> Option<LabeledType> {
         match self {
             Schema::Bool(_) => None,
-            Schema::Object(obj) => obj.try_as_labeled_type(),
+            Schema::Object(obj) => obj.try_into_labeled_type(),
         }
     }
 }
 
-impl TryAsContract for &ObjectValidation {
-    fn try_as_contract(self) -> Option<RichTerm> {
+impl TryIntoContract for &ObjectValidation {
+    fn try_into_contract(self) -> Option<RichTerm> {
         fn is_open_record(additional: Option<&Schema>) -> bool {
             match additional {
                 Some(Schema::Bool(open)) => *open,
@@ -178,8 +178,8 @@ impl TryAsContract for &ObjectValidation {
     }
 }
 
-impl TryAsContract for &SchemaObject {
-    fn try_as_contract(self) -> Option<RichTerm> {
+impl TryIntoContract for &SchemaObject {
+    fn try_into_contract(self) -> Option<RichTerm> {
         match self {
             // a reference to a definition
             SchemaObject {
@@ -232,24 +232,24 @@ impl TryAsContract for &SchemaObject {
                 reference: None,
                 extensions,
             } if **instance_type == InstanceType::Object && extensions.is_empty() => {
-                ov.as_ref().try_as_contract()
+                ov.as_ref().try_into_contract()
             }
             _ => None,
         }
     }
 }
 
-impl TryAsContract for &Schema {
-    fn try_as_contract(self) -> Option<RichTerm> {
+impl TryIntoContract for &Schema {
+    fn try_into_contract(self) -> Option<RichTerm> {
         match self {
             Schema::Bool(_) => None,
-            Schema::Object(obj) => obj.try_as_contract(),
+            Schema::Object(obj) => obj.try_into_contract(),
         }
     }
 }
 
-impl AsLabeledType for RichTerm {
-    fn as_labeled_type(self) -> LabeledType {
+impl IntoLabeledType for RichTerm {
+    fn into_labeled_type(self) -> LabeledType {
         LabeledType {
             types: TypeF::Flat(self).into(),
             label: Label::dummy(),
@@ -267,12 +267,12 @@ fn generate_record_contract(
             // record fields where anything is allowed should look like
             // { a, b } not { a | predicates.always, b | predicates.always }
             vec![]
-        } else if let Some(t) = schema.try_as_labeled_type() {
+        } else if let Some(t) = schema.try_into_labeled_type() {
             vec![t]
-        } else if let Some(term) = schema.try_as_contract() {
-            vec![term.as_labeled_type()]
+        } else if let Some(term) = schema.try_into_contract() {
+            vec![term.into_labeled_type()]
         } else {
-            vec![contract_from_predicate(schema.as_predicate()).as_labeled_type()]
+            vec![contract_from_predicate(schema.into_predicate()).into_labeled_type()]
         };
         (
             name.into(),

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -43,22 +43,22 @@ use crate::{definitions, predicates::AsPredicate, utils::static_access};
 
 /// Convert to a Nickel [`RichtTerm`] representing a contract.
 pub trait AsContract {
-    fn as_contract(self) -> RichTerm;
+    fn as_contract(&self) -> RichTerm;
 }
 
 /// Convert to a Nickel [`RichtTerm`] representing a contract, if possible.
 pub trait TryAsContract {
-    fn try_as_contract(self) -> Option<RichTerm>;
+    fn try_as_contract(&self) -> Option<RichTerm>;
 }
 
 /// Convert to a Nickel [`LabeledType`]
 pub trait AsLabeledType {
-    fn as_labeled_type(self) -> LabeledType;
+    fn as_labeled_type(&self) -> LabeledType;
 }
 
 /// Convert to a Nickel [`LabeledType`], if possible.
 pub trait TryAsLabeledType {
-    fn try_as_labeled_type(self) -> Option<LabeledType>;
+    fn try_as_labeled_type(&self) -> Option<LabeledType>;
 }
 
 /// Convert an [`InstanceType`] into a Nickel [`RichTerm`]. We're in a bit of a
@@ -72,7 +72,7 @@ pub trait TryAsLabeledType {
 /// but the pretty printer not understanding that builtin type names are not
 /// valid identifiers.
 impl AsContract for InstanceType {
-    fn as_contract(self) -> RichTerm {
+    fn as_contract(&self) -> RichTerm {
         match self {
             InstanceType::Null => contract_from_predicate(mk_app!(
                 static_access("predicates", ["isType"]),
@@ -93,7 +93,7 @@ impl AsContract for InstanceType {
 }
 
 impl AsLabeledType for InstanceType {
-    fn as_labeled_type(self) -> LabeledType {
+    fn as_labeled_type(&self) -> LabeledType {
         let types = match self {
             InstanceType::Boolean => TypeF::Bool.into(),
             InstanceType::Array => TypeF::Array(Box::new(Types::from(TypeF::Dyn))).into(),
@@ -110,8 +110,8 @@ impl AsLabeledType for InstanceType {
     }
 }
 
-impl TryAsLabeledType for &SchemaObject {
-    fn try_as_labeled_type(self) -> Option<LabeledType> {
+impl TryAsLabeledType for SchemaObject {
+    fn try_as_labeled_type(&self) -> Option<LabeledType> {
         match self {
             SchemaObject {
                 metadata: _,
@@ -133,8 +133,8 @@ impl TryAsLabeledType for &SchemaObject {
     }
 }
 
-impl TryAsLabeledType for &Schema {
-    fn try_as_labeled_type(self) -> Option<LabeledType> {
+impl TryAsLabeledType for Schema {
+    fn try_as_labeled_type(&self) -> Option<LabeledType> {
         match self {
             Schema::Bool(_) => None,
             Schema::Object(obj) => obj.try_as_labeled_type(),
@@ -142,8 +142,8 @@ impl TryAsLabeledType for &Schema {
     }
 }
 
-impl TryAsContract for &ObjectValidation {
-    fn try_as_contract(self) -> Option<RichTerm> {
+impl TryAsContract for ObjectValidation {
+    fn try_as_contract(&self) -> Option<RichTerm> {
         fn is_open_record(additional: Option<&Schema>) -> bool {
             match additional {
                 Some(Schema::Bool(open)) => *open,
@@ -178,8 +178,8 @@ impl TryAsContract for &ObjectValidation {
     }
 }
 
-impl TryAsContract for &SchemaObject {
-    fn try_as_contract(self) -> Option<RichTerm> {
+impl TryAsContract for SchemaObject {
+    fn try_as_contract(&self) -> Option<RichTerm> {
         match self {
             // a reference to a definition
             SchemaObject {
@@ -239,8 +239,8 @@ impl TryAsContract for &SchemaObject {
     }
 }
 
-impl TryAsContract for &Schema {
-    fn try_as_contract(self) -> Option<RichTerm> {
+impl TryAsContract for Schema {
+    fn try_as_contract(&self) -> Option<RichTerm> {
         match self {
             Schema::Bool(_) => None,
             Schema::Object(obj) => obj.try_as_contract(),
@@ -249,9 +249,9 @@ impl TryAsContract for &Schema {
 }
 
 impl AsLabeledType for RichTerm {
-    fn as_labeled_type(self) -> LabeledType {
+    fn as_labeled_type(&self) -> LabeledType {
         LabeledType {
-            types: TypeF::Flat(self).into(),
+            types: TypeF::Flat(self.clone()).into(),
             label: Label::dummy(),
         }
     }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -19,8 +19,8 @@ use nickel_lang_core::{
 use schemars::schema::Schema;
 
 use crate::{
-    contracts::{contract_from_predicate, TryAsContract},
-    predicates::AsPredicate,
+    contracts::{contract_from_predicate, TryIntoContract},
+    predicates::IntoPredicate,
     utils::static_access,
 };
 
@@ -115,12 +115,12 @@ impl From<&BTreeMap<String, Schema>> for Environment {
         let terms = defs
             .iter()
             .map(|(name, schema)| {
-                let predicate = schema.as_predicate();
+                let predicate = schema.into_predicate();
                 (
                     name.clone(),
                     ConvertedSchema {
                         contract: schema
-                            .try_as_contract()
+                            .try_into_contract()
                             .unwrap_or_else(|| contract_from_predicate(access(name).predicate)),
                         predicate,
                     },

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -20,7 +20,7 @@ use schemars::schema::Schema;
 
 use crate::{
     contracts::{contract_from_predicate, TryAsContract},
-    predicates::schema_to_predicate,
+    predicates::AsPredicate,
     utils::static_access,
 };
 
@@ -115,7 +115,7 @@ impl From<&BTreeMap<String, Schema>> for Environment {
         let terms = defs
             .iter()
             .map(|(name, schema)| {
-                let predicate = schema_to_predicate(schema);
+                let predicate = schema.as_predicate();
                 (
                     name.clone(),
                     ConvertedSchema {

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -19,7 +19,7 @@ use nickel_lang_core::{
 use schemars::schema::Schema;
 
 use crate::{
-    contracts::{contract_from_predicate, schema_to_contract},
+    contracts::{contract_from_predicate, TryAsContract},
     predicates::schema_to_predicate,
     utils::static_access,
 };
@@ -119,7 +119,8 @@ impl From<&BTreeMap<String, Schema>> for Environment {
                 (
                     name.clone(),
                     ConvertedSchema {
-                        contract: schema_to_contract(schema)
+                        contract: schema
+                            .try_as_contract()
                             .unwrap_or_else(|| contract_from_predicate(access(name).predicate)),
                         predicate,
                     },

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -19,8 +19,8 @@ use nickel_lang_core::{
 use schemars::schema::Schema;
 
 use crate::{
-    contracts::{contract_from_predicate, TryIntoContract},
-    predicates::IntoPredicate,
+    contracts::{contract_from_predicate, TryAsContract},
+    predicates::AsPredicate,
     utils::static_access,
 };
 
@@ -115,12 +115,12 @@ impl From<&BTreeMap<String, Schema>> for Environment {
         let terms = defs
             .iter()
             .map(|(name, schema)| {
-                let predicate = schema.into_predicate();
+                let predicate = schema.as_predicate();
                 (
                     name.clone(),
                     ConvertedSchema {
                         contract: schema
-                            .try_into_contract()
+                            .try_as_contract()
                             .unwrap_or_else(|| contract_from_predicate(access(name).predicate)),
                         predicate,
                     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod definitions;
 pub mod predicates;
 pub(crate) mod utils;
 
-use contracts::{contract_from_predicate, schema_object_to_contract};
+use contracts::{contract_from_predicate, TryAsContract};
 use definitions::Environment;
 use nickel_lang_core::term::{RichTerm, Term};
 use predicates::schema_object_to_predicate;
@@ -35,7 +35,7 @@ use schemars::schema::RootSchema;
 /// Otherwise, we fall back to generating a predicate.
 pub fn root_schema(root: &RootSchema) -> RichTerm {
     let env = Environment::from(&root.definitions);
-    if let Some(contract) = schema_object_to_contract(&root.schema) {
+    if let Some(contract) = root.schema.try_as_contract() {
         wrap_contract(env, contract)
     } else {
         let predicate = schema_object_to_predicate(&root.schema);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub(crate) mod utils;
 use contracts::{contract_from_predicate, TryAsContract};
 use definitions::Environment;
 use nickel_lang_core::term::{RichTerm, Term};
-use predicates::schema_object_to_predicate;
+use predicates::AsPredicate;
 use schemars::schema::RootSchema;
 
 /// Convert a [`RootSchema`] into a Nickel contract. If the JSON schema is
@@ -38,7 +38,7 @@ pub fn root_schema(root: &RootSchema) -> RichTerm {
     if let Some(contract) = root.schema.try_as_contract() {
         wrap_contract(env, contract)
     } else {
-        let predicate = schema_object_to_predicate(&root.schema);
+        let predicate = root.schema.as_predicate();
         wrap_predicate(env, predicate)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,10 @@ pub mod definitions;
 pub mod predicates;
 pub(crate) mod utils;
 
-use contracts::{contract_from_predicate, TryAsContract};
+use contracts::{contract_from_predicate, TryIntoContract};
 use definitions::Environment;
 use nickel_lang_core::term::{RichTerm, Term};
-use predicates::AsPredicate;
+use predicates::IntoPredicate;
 use schemars::schema::RootSchema;
 
 /// Convert a [`RootSchema`] into a Nickel contract. If the JSON schema is
@@ -35,10 +35,10 @@ use schemars::schema::RootSchema;
 /// Otherwise, we fall back to generating a predicate.
 pub fn root_schema(root: &RootSchema) -> RichTerm {
     let env = Environment::from(&root.definitions);
-    if let Some(contract) = root.schema.try_as_contract() {
+    if let Some(contract) = root.schema.try_into_contract() {
         wrap_contract(env, contract)
     } else {
-        let predicate = root.schema.as_predicate();
+        let predicate = root.schema.into_predicate();
         wrap_predicate(env, predicate)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,10 @@ pub mod definitions;
 pub mod predicates;
 pub(crate) mod utils;
 
-use contracts::{contract_from_predicate, TryIntoContract};
+use contracts::{contract_from_predicate, TryAsContract};
 use definitions::Environment;
 use nickel_lang_core::term::{RichTerm, Term};
-use predicates::IntoPredicate;
+use predicates::AsPredicate;
 use schemars::schema::RootSchema;
 
 /// Convert a [`RootSchema`] into a Nickel contract. If the JSON schema is
@@ -35,10 +35,10 @@ use schemars::schema::RootSchema;
 /// Otherwise, we fall back to generating a predicate.
 pub fn root_schema(root: &RootSchema) -> RichTerm {
     let env = Environment::from(&root.definitions);
-    if let Some(contract) = root.schema.try_into_contract() {
+    if let Some(contract) = root.schema.try_as_contract() {
         wrap_contract(env, contract)
     } else {
-        let predicate = root.schema.into_predicate();
+        let predicate = root.schema.as_predicate();
         wrap_predicate(env, predicate)
     }
 }

--- a/src/predicates.rs
+++ b/src/predicates.rs
@@ -58,7 +58,7 @@ impl AsPredicate for &SingleOrVec<InstanceType> {
     }
 }
 
-/// XXX enum
+/// Convert a json schema Enum to a predicate. Enums are represented as &[Value].
 impl AsPredicate for &[Value] {
     fn as_predicate(self) -> RichTerm {
         mk_app!(
@@ -75,6 +75,7 @@ impl AsPredicate for &[Value] {
     }
 }
 
+/// Convert a json schema Const to a predicate. Consts are represented as Values
 impl AsPredicate for &Value {
     fn as_predicate(self) -> RichTerm {
         Term::App(

--- a/src/predicates.rs
+++ b/src/predicates.rs
@@ -13,57 +13,76 @@ use serde_json::Value;
 
 use crate::{definitions, utils::static_access};
 
+pub trait AsPredicate {
+    fn as_predicate(self) -> RichTerm;
+}
+
+pub trait AsPredicates {
+    // TODO: Turn Vec<_> into Iterator<Item = _> when RPTIT is implemented
+    // SEE: https://rust-lang.github.io/impl-trait-initiative/RFCs/rpit-in-traits.html
+    fn as_predicates(self) -> Vec<RichTerm>;
+}
+
 fn or_always(s: Option<&Schema>) -> RichTerm {
-    s.map(schema_to_predicate)
+    s.map(|s| s.as_predicate())
         .unwrap_or(static_access("predicates", ["always"]))
 }
 
-fn type_to_predicate(x: InstanceType) -> RichTerm {
-    let type_tag = match x {
-        InstanceType::Null => Term::Enum("Null".into()),
-        InstanceType::Boolean => Term::Enum("Bool".into()),
-        InstanceType::Object => Term::Enum("Record".into()),
-        InstanceType::Array => Term::Enum("Array".into()),
-        InstanceType::Number => Term::Enum("Number".into()),
-        InstanceType::String => Term::Enum("String".into()),
-        InstanceType::Integer => Term::Enum("Integer".into()),
-    };
-    mk_app!(static_access("predicates", ["isType"]), type_tag)
-}
-
-fn types_to_predicate(x: &SingleOrVec<InstanceType>) -> RichTerm {
-    match x {
-        SingleOrVec::Single(t) => type_to_predicate(**t),
-        SingleOrVec::Vec(ts) => mk_app!(
-            static_access("predicates", ["anyOf"]),
-            Term::Array(
-                Array::new(ts.iter().map(|t| type_to_predicate(*t)).collect()),
-                Default::default()
-            )
-        ),
+impl AsPredicate for InstanceType {
+    fn as_predicate(self) -> RichTerm {
+        let type_tag = match self {
+            InstanceType::Null => Term::Enum("Null".into()),
+            InstanceType::Boolean => Term::Enum("Bool".into()),
+            InstanceType::Object => Term::Enum("Record".into()),
+            InstanceType::Array => Term::Enum("Array".into()),
+            InstanceType::Number => Term::Enum("Number".into()),
+            InstanceType::String => Term::Enum("String".into()),
+            InstanceType::Integer => Term::Enum("Integer".into()),
+        };
+        mk_app!(static_access("predicates", ["isType"]), type_tag)
     }
 }
 
-fn enum_to_predicate(vs: &[Value]) -> RichTerm {
-    mk_app!(
-        static_access("predicates", ["enum"]),
-        Term::Array(
-            Array::new(
-                vs.iter()
-                    .map(|v| serde_json::from_value(v.clone()).unwrap())
-                    .collect()
+impl AsPredicate for &SingleOrVec<InstanceType> {
+    fn as_predicate(self) -> RichTerm {
+        match self {
+            SingleOrVec::Single(t) => t.as_predicate(),
+            SingleOrVec::Vec(ts) => mk_app!(
+                static_access("predicates", ["anyOf"]),
+                Term::Array(
+                    Array::new(ts.iter().map(|t| t.as_predicate()).collect()),
+                    Default::default()
+                )
             ),
-            Default::default()
-        )
-    )
+        }
+    }
 }
 
-fn const_to_predicate(v: &Value) -> RichTerm {
-    Term::App(
-        static_access("predicates", ["const"]),
-        serde_json::from_value(v.clone()).unwrap(),
-    )
-    .into()
+/// XXX enum
+impl AsPredicate for &[Value] {
+    fn as_predicate(self) -> RichTerm {
+        mk_app!(
+            static_access("predicates", ["enum"]),
+            Term::Array(
+                Array::new(
+                    self.iter()
+                        .map(|v| serde_json::from_value(v.clone()).unwrap())
+                        .collect()
+                ),
+                Default::default()
+            )
+        )
+    }
+}
+
+impl AsPredicate for &Value {
+    fn as_predicate(self) -> RichTerm {
+        Term::App(
+            static_access("predicates", ["const"]),
+            serde_json::from_value(self.clone()).unwrap(),
+        )
+        .into()
+    }
 }
 
 fn mk_all_of(schemas: impl IntoIterator<Item = RichTerm>) -> RichTerm {
@@ -90,291 +109,311 @@ fn mk_any_of(schemas: impl IntoIterator<Item = RichTerm>) -> RichTerm {
     }
 }
 
-fn subschema_predicates(subschemas: &SubschemaValidation) -> impl Iterator<Item = RichTerm> {
-    let SubschemaValidation {
-        all_of,
-        any_of,
-        one_of,
-        not,
-        if_schema,
-        then_schema,
-        else_schema,
-    } = subschemas;
+impl AsPredicates for &SubschemaValidation {
+    fn as_predicates(self) -> Vec<RichTerm> {
+        let SubschemaValidation {
+            all_of,
+            any_of,
+            one_of,
+            not,
+            if_schema,
+            then_schema,
+            else_schema,
+        } = self;
 
-    let all_of = all_of
-        .as_deref()
-        .map(|schemas| mk_all_of(schemas.iter().map(schema_to_predicate)))
-        .into_iter();
+        let all_of = all_of
+            .as_deref()
+            .map(|schemas| mk_all_of(schemas.iter().map(|s| s.as_predicate())))
+            .into_iter();
 
-    let any_of = any_of
-        .as_deref()
-        .map(|schemas| mk_any_of(schemas.iter().map(schema_to_predicate)))
-        .into_iter();
+        let any_of = any_of
+            .as_deref()
+            .map(|schemas| mk_any_of(schemas.iter().map(|s| s.as_predicate())))
+            .into_iter();
 
-    let one_of = one_of
-        .as_deref()
-        .map(|schemas| {
-            mk_app!(
-                static_access("predicates", ["oneOf"]),
-                Term::Array(
-                    Array::new(schemas.iter().map(schema_to_predicate).collect()),
-                    Default::default()
-                )
-            )
-        })
-        .into_iter();
-
-    let not = not
-        .as_deref()
-        .map(|s| mk_app!(static_access("predicates", ["not"]), schema_to_predicate(s)))
-        .into_iter();
-
-    let ite = if_schema
-        .as_deref()
-        .map(move |if_schema| {
-            mk_app!(
-                static_access("predicates", ["ifThenElse"]),
-                schema_to_predicate(if_schema),
-                or_always(then_schema.as_deref()),
-                or_always(else_schema.as_deref())
-            )
-        })
-        .into_iter();
-
-    all_of.chain(any_of).chain(one_of).chain(not).chain(ite)
-}
-
-fn number_predicates(nv: &NumberValidation) -> impl Iterator<Item = RichTerm> {
-    let NumberValidation {
-        multiple_of,
-        maximum,
-        exclusive_maximum,
-        minimum,
-        exclusive_minimum,
-    } = nv;
-
-    fn predicate(s: &str) -> impl '_ + FnOnce(f64) -> RichTerm {
-        move |n| {
-            mk_app!(
-                static_access("predicates", ["numbers", s]),
-                Term::Num(Number::try_from_float_simplest(n).unwrap())
-            )
-        }
-    }
-
-    let multiple_of = multiple_of.map(predicate("multipleOf")).into_iter();
-    let maximum = maximum.map(predicate("maximum")).into_iter();
-    let exclusive_maximum = exclusive_maximum
-        .map(predicate("exclusiveMaximum"))
-        .into_iter();
-    let minimum = minimum.map(predicate("minimum")).into_iter();
-    let exclusive_minimum = exclusive_minimum
-        .map(predicate("exclusiveMinimum"))
-        .into_iter();
-
-    multiple_of
-        .chain(maximum)
-        .chain(exclusive_maximum)
-        .chain(minimum)
-        .chain(exclusive_minimum)
-}
-
-fn string_predicates(sv: &StringValidation) -> impl Iterator<Item = RichTerm> {
-    let StringValidation {
-        max_length,
-        min_length,
-        pattern,
-    } = sv;
-
-    let max_length = max_length
-        .map(|n| {
-            mk_app!(
-                static_access("predicates", ["strings", "maxLength"]),
-                Term::Num(n.into())
-            )
-        })
-        .into_iter();
-
-    let min_length = min_length
-        .map(|n| {
-            mk_app!(
-                static_access("predicates", ["strings", "minLength"]),
-                Term::Num(n.into())
-            )
-        })
-        .into_iter();
-
-    let pattern = pattern
-        .as_deref()
-        .map(|s| {
-            mk_app!(
-                static_access("predicates", ["strings", "pattern"]),
-                make::string(s)
-            )
-        })
-        .into_iter();
-
-    max_length.chain(min_length).chain(pattern)
-}
-
-fn array_predicates(av: &ArrayValidation) -> impl Iterator<Item = RichTerm> {
-    let ArrayValidation {
-        items,
-        additional_items,
-        max_items,
-        min_items,
-        unique_items,
-        contains,
-    } = av;
-
-    let items = match items {
-        None => vec![],
-        Some(SingleOrVec::Single(s)) => vec![mk_app!(
-            static_access("predicates", ["arrays", "arrayOf"]),
-            schema_to_predicate(s)
-        )],
-        Some(SingleOrVec::Vec(schemas)) => {
-            let len = schemas.len();
-            [mk_app!(
-                static_access("predicates", ["arrays", "items"]),
-                Term::Array(
-                    Array::new(schemas.iter().map(schema_to_predicate).collect()),
-                    Default::default()
-                )
-            )]
-            .into_iter()
-            .chain(additional_items.as_deref().map(|s| {
+        let one_of = one_of
+            .as_deref()
+            .map(|schemas| {
                 mk_app!(
-                    static_access("predicates", ["arrays", "additionalItems"]),
-                    schema_to_predicate(s),
-                    Term::Num(len.into())
+                    static_access("predicates", ["oneOf"]),
+                    Term::Array(
+                        Array::new(schemas.iter().map(|schema| schema.as_predicate()).collect()),
+                        Default::default()
+                    )
                 )
-            }))
+            })
+            .into_iter();
+
+        let not = not
+            .as_deref()
+            .map(|s| mk_app!(static_access("predicates", ["not"]), s.as_predicate()))
+            .into_iter();
+
+        let ite = if_schema
+            .as_deref()
+            .map(move |if_schema| {
+                mk_app!(
+                    static_access("predicates", ["ifThenElse"]),
+                    if_schema.as_predicate(),
+                    or_always(then_schema.as_deref()),
+                    or_always(else_schema.as_deref())
+                )
+            })
+            .into_iter();
+
+        all_of
+            .chain(any_of)
+            .chain(one_of)
+            .chain(not)
+            .chain(ite)
             .collect()
-        }
     }
-    .into_iter();
-
-    let max_items = max_items
-        .map(|n| {
-            mk_app!(
-                static_access("predicates", ["arrays", "maxItems"]),
-                Term::Num(n.into())
-            )
-        })
-        .into_iter();
-
-    let min_items = min_items
-        .map(|n| {
-            mk_app!(
-                static_access("predicates", ["arrays", "minItems"]),
-                Term::Num(n.into())
-            )
-        })
-        .into_iter();
-
-    let unique_items = unique_items
-        .and_then(|unique| unique.then_some(static_access("predicates", ["arrays", "uniqueItems"])))
-        .into_iter();
-
-    let contains = contains
-        .as_deref()
-        .map(|s| {
-            mk_app!(
-                static_access("predicates", ["arrays", "contains"]),
-                schema_to_predicate(s)
-            )
-        })
-        .into_iter();
-
-    items
-        .chain(max_items)
-        .chain(min_items)
-        .chain(unique_items)
-        .chain(contains)
 }
 
-fn object_predicates(ov: &ObjectValidation) -> impl Iterator<Item = RichTerm> {
-    let ObjectValidation {
-        max_properties,
-        min_properties,
-        required,
-        properties,
-        pattern_properties,
-        additional_properties,
-        property_names,
-    } = ov;
+impl AsPredicates for &NumberValidation {
+    fn as_predicates(self) -> Vec<RichTerm> {
+        let NumberValidation {
+            multiple_of,
+            maximum,
+            exclusive_maximum,
+            minimum,
+            exclusive_minimum,
+        } = self;
 
-    let max_properties = max_properties
-        .map(|n| {
-            mk_app!(
-                static_access("predicates", ["records", "maxProperties"]),
-                Term::Num(n.into())
-            )
-        })
-        .into_iter();
-
-    let min_properties = min_properties
-        .map(|n| {
-            mk_app!(
-                static_access("predicates", ["records", "minProperties"]),
-                Term::Num(n.into())
-            )
-        })
-        .into_iter();
-
-    let property_names = property_names
-        .as_deref()
-        .map(|s| {
-            mk_app!(
-                static_access("predicates", ["records", "propertyNames"]),
-                schema_to_predicate(s)
-            )
-        })
-        .into_iter();
-
-    let required = {
-        if required.is_empty() {
-            None
-        } else {
-            Some(mk_app!(
-                static_access("predicates", ["records", "required"]),
-                Term::Array(
-                    Array::new(required.iter().map(make::string).collect()),
-                    Default::default()
+        fn predicate(s: &str) -> impl '_ + FnOnce(f64) -> RichTerm {
+            move |n| {
+                mk_app!(
+                    static_access("predicates", ["numbers", s]),
+                    Term::Num(Number::try_from_float_simplest(n).unwrap())
                 )
-            ))
+            }
         }
+
+        let multiple_of = multiple_of.map(predicate("multipleOf")).into_iter();
+        let maximum = maximum.map(predicate("maximum")).into_iter();
+        let exclusive_maximum = exclusive_maximum
+            .map(predicate("exclusiveMaximum"))
+            .into_iter();
+        let minimum = minimum.map(predicate("minimum")).into_iter();
+        let exclusive_minimum = exclusive_minimum
+            .map(predicate("exclusiveMinimum"))
+            .into_iter();
+
+        multiple_of
+            .chain(maximum)
+            .chain(exclusive_maximum)
+            .chain(minimum)
+            .chain(exclusive_minimum)
+            .collect()
     }
-    .into_iter();
+}
 
-    let record = [mk_app!(
-        static_access("predicates", ["records", "record"]),
-        Term::Record(RecordData::with_field_values(
-            properties
-                .iter()
-                .map(|(k, v)| (k.into(), schema_to_predicate(v)))
-                .collect()
-        )),
-        Term::Record(RecordData::with_field_values(
-            pattern_properties
-                .iter()
-                .map(|(k, v)| (k.into(), schema_to_predicate(v)))
-                .collect()
-        )),
-        Term::Bool(!matches!(
-            additional_properties.as_deref(),
-            Some(Schema::Bool(false))
-        )),
-        or_always(additional_properties.as_deref())
-    )]
-    .into_iter();
+impl AsPredicates for &StringValidation {
+    fn as_predicates(self) -> Vec<RichTerm> {
+        let StringValidation {
+            max_length,
+            min_length,
+            pattern,
+        } = self;
 
-    max_properties
-        .chain(min_properties)
-        .chain(property_names)
-        .chain(required)
-        .chain(record)
+        let max_length = max_length
+            .map(|n| {
+                mk_app!(
+                    static_access("predicates", ["strings", "maxLength"]),
+                    Term::Num(n.into())
+                )
+            })
+            .into_iter();
+
+        let min_length = min_length
+            .map(|n| {
+                mk_app!(
+                    static_access("predicates", ["strings", "minLength"]),
+                    Term::Num(n.into())
+                )
+            })
+            .into_iter();
+
+        let pattern = pattern
+            .as_deref()
+            .map(|s| {
+                mk_app!(
+                    static_access("predicates", ["strings", "pattern"]),
+                    make::string(s)
+                )
+            })
+            .into_iter();
+
+        max_length.chain(min_length).chain(pattern).collect()
+    }
+}
+
+impl AsPredicates for &ArrayValidation {
+    fn as_predicates(self) -> Vec<RichTerm> {
+        let ArrayValidation {
+            items,
+            additional_items,
+            max_items,
+            min_items,
+            unique_items,
+            contains,
+        } = self;
+
+        let items = match items {
+            None => vec![],
+            Some(SingleOrVec::Single(s)) => vec![mk_app!(
+                static_access("predicates", ["arrays", "arrayOf"]),
+                s.as_predicate()
+            )],
+            Some(SingleOrVec::Vec(schemas)) => {
+                let len = schemas.len();
+                [mk_app!(
+                    static_access("predicates", ["arrays", "items"]),
+                    Term::Array(
+                        Array::new(schemas.iter().map(|x| x.as_predicate()).collect()),
+                        Default::default()
+                    )
+                )]
+                .into_iter()
+                .chain(additional_items.as_deref().map(|s| {
+                    mk_app!(
+                        static_access("predicates", ["arrays", "additionalItems"]),
+                        s.as_predicate(),
+                        Term::Num(len.into())
+                    )
+                }))
+                .collect()
+            }
+        }
+        .into_iter();
+
+        let max_items = max_items
+            .map(|n| {
+                mk_app!(
+                    static_access("predicates", ["arrays", "maxItems"]),
+                    Term::Num(n.into())
+                )
+            })
+            .into_iter();
+
+        let min_items = min_items
+            .map(|n| {
+                mk_app!(
+                    static_access("predicates", ["arrays", "minItems"]),
+                    Term::Num(n.into())
+                )
+            })
+            .into_iter();
+
+        let unique_items = unique_items
+            .and_then(|unique| {
+                unique.then_some(static_access("predicates", ["arrays", "uniqueItems"]))
+            })
+            .into_iter();
+
+        let contains = contains
+            .as_deref()
+            .map(|s| {
+                mk_app!(
+                    static_access("predicates", ["arrays", "contains"]),
+                    s.as_predicate()
+                )
+            })
+            .into_iter();
+
+        items
+            .chain(max_items)
+            .chain(min_items)
+            .chain(unique_items)
+            .chain(contains)
+            .collect()
+    }
+}
+
+impl AsPredicates for &ObjectValidation {
+    fn as_predicates(self) -> Vec<RichTerm> {
+        let ObjectValidation {
+            max_properties,
+            min_properties,
+            required,
+            properties,
+            pattern_properties,
+            additional_properties,
+            property_names,
+        } = self;
+
+        let max_properties = max_properties
+            .map(|n| {
+                mk_app!(
+                    static_access("predicates", ["records", "maxProperties"]),
+                    Term::Num(n.into())
+                )
+            })
+            .into_iter();
+
+        let min_properties = min_properties
+            .map(|n| {
+                mk_app!(
+                    static_access("predicates", ["records", "minProperties"]),
+                    Term::Num(n.into())
+                )
+            })
+            .into_iter();
+
+        let property_names = property_names
+            .as_deref()
+            .map(|s| {
+                mk_app!(
+                    static_access("predicates", ["records", "propertyNames"]),
+                    s.as_predicate()
+                )
+            })
+            .into_iter();
+
+        let required = {
+            if required.is_empty() {
+                None
+            } else {
+                Some(mk_app!(
+                    static_access("predicates", ["records", "required"]),
+                    Term::Array(
+                        Array::new(required.iter().map(make::string).collect()),
+                        Default::default()
+                    )
+                ))
+            }
+        }
+        .into_iter();
+
+        let record = [mk_app!(
+            static_access("predicates", ["records", "record"]),
+            Term::Record(RecordData::with_field_values(
+                properties
+                    .iter()
+                    .map(|(k, v)| (k.into(), v.as_predicate()))
+                    .collect()
+            )),
+            Term::Record(RecordData::with_field_values(
+                pattern_properties
+                    .iter()
+                    .map(|(k, v)| (k.into(), v.as_predicate()))
+                    .collect()
+            )),
+            Term::Bool(!matches!(
+                additional_properties.as_deref(),
+                Some(Schema::Bool(false))
+            )),
+            or_always(additional_properties.as_deref())
+        )]
+        .into_iter();
+
+        max_properties
+            .chain(min_properties)
+            .chain(property_names)
+            .chain(required)
+            .chain(record)
+            .collect()
+    }
 }
 
 fn dependencies(extensions: &BTreeMap<String, Value>) -> impl Iterator<Item = RichTerm> {
@@ -400,7 +439,7 @@ fn dependencies(extensions: &BTreeMap<String, Value>) -> impl Iterator<Item = Ri
                                 .into()
                             } else {
                                 serde_json::from_value::<Schema>(value.clone())
-                                    .map(|s| schema_to_predicate(&s))
+                                    .map(|s| s.as_predicate())
                                     .unwrap()
                             }
                         ))
@@ -411,52 +450,56 @@ fn dependencies(extensions: &BTreeMap<String, Value>) -> impl Iterator<Item = Ri
         .into_iter()
 }
 
-pub fn schema_object_to_predicate(o: &SchemaObject) -> RichTerm {
-    // NOTE: You may naively think that, for instance, numbers and strings are
-    // mutually exclusive. Not to a json schema! Any number of these fields can
-    // be set and the semantics is they get ANDed together, even if that can
-    // never pass.
-    let SchemaObject {
-        metadata: _,
-        instance_type,
-        format: _, // TODO(vkleen): deal with string formats
-        enum_values,
-        const_value,
-        subschemas,
-        number,
-        string,
-        array,
-        object,
-        reference,
-        extensions,
-    } = o;
-    mk_all_of(
-        instance_type
-            .iter()
-            .map(types_to_predicate)
-            .chain(enum_values.as_deref().map(enum_to_predicate))
-            .chain(const_value.as_ref().map(const_to_predicate))
-            .chain(subschemas.iter().flat_map(|s| subschema_predicates(s)))
-            .chain(number.iter().flat_map(|nv| number_predicates(nv)))
-            .chain(string.iter().flat_map(|sv| string_predicates(sv)))
-            .chain(array.iter().flat_map(|av| array_predicates(av)))
-            .chain(object.iter().flat_map(|ov| object_predicates(ov)))
-            .chain(
-                reference
-                    .as_deref()
-                    .map(|r| definitions::reference(r).predicate),
-            )
-            // schema.rs parses dependencies incorrectly. It should really be
-            // part of object validation (object_predicates()) but it gets put
-            // in extensions instead.
-            .chain(dependencies(extensions)),
-    )
+impl AsPredicate for &SchemaObject {
+    fn as_predicate(self) -> RichTerm {
+        // NOTE: You may naively think that, for instance, numbers and strings are
+        // mutually exclusive. Not to a json schema! Any number of these fields can
+        // be set and the semantics is they get ANDed together, even if that can
+        // never pass.
+        let SchemaObject {
+            metadata: _,
+            instance_type,
+            format: _, // TODO(vkleen): deal with string formats
+            enum_values,
+            const_value,
+            subschemas,
+            number,
+            string,
+            array,
+            object,
+            reference,
+            extensions,
+        } = self;
+        mk_all_of(
+            instance_type
+                .iter()
+                .map(|x| x.as_predicate())
+                .chain(enum_values.as_deref().map(|x| x.as_predicate()))
+                .chain(const_value.as_ref().map(|x| x.as_predicate()))
+                .chain(subschemas.iter().flat_map(|x| x.as_predicates()))
+                .chain(number.iter().flat_map(|x| x.as_predicates()))
+                .chain(string.iter().flat_map(|x| x.as_predicates()))
+                .chain(array.iter().flat_map(|x| x.as_predicates()))
+                .chain(object.iter().flat_map(|x| x.as_predicates()))
+                .chain(
+                    reference
+                        .as_deref()
+                        .map(|r| definitions::reference(r).predicate),
+                )
+                // schema.rs parses dependencies incorrectly. It should really be
+                // part of object validation (object_predicates()) but it gets put
+                // in extensions instead.
+                .chain(dependencies(extensions)),
+        )
+    }
 }
 
-pub fn schema_to_predicate(schema: &Schema) -> RichTerm {
-    match schema {
-        Schema::Bool(true) => static_access("predicates", ["always"]),
-        Schema::Bool(false) => static_access("predicates", ["never"]),
-        Schema::Object(o) => schema_object_to_predicate(o),
+impl AsPredicate for &Schema {
+    fn as_predicate(self) -> RichTerm {
+        match self {
+            Schema::Bool(true) => static_access("predicates", ["always"]),
+            Schema::Bool(false) => static_access("predicates", ["never"]),
+            Schema::Object(o) => o.as_predicate(),
+        }
     }
 }

--- a/src/predicates.rs
+++ b/src/predicates.rs
@@ -14,13 +14,13 @@ use serde_json::Value;
 use crate::{definitions, utils::static_access};
 
 pub trait AsPredicate {
-    fn as_predicate(self) -> RichTerm;
+    fn as_predicate(&self) -> RichTerm;
 }
 
 pub trait AsPredicates {
     // TODO: Turn Vec<_> into Iterator<Item = _> when RPTIT is implemented
     // SEE: https://rust-lang.github.io/impl-trait-initiative/RFCs/rpit-in-traits.html
-    fn as_predicates(self) -> Vec<RichTerm>;
+    fn as_predicates(&self) -> Vec<RichTerm>;
 }
 
 fn or_always(s: Option<&Schema>) -> RichTerm {
@@ -29,7 +29,7 @@ fn or_always(s: Option<&Schema>) -> RichTerm {
 }
 
 impl AsPredicate for InstanceType {
-    fn as_predicate(self) -> RichTerm {
+    fn as_predicate(&self) -> RichTerm {
         let type_tag = match self {
             InstanceType::Null => Term::Enum("Null".into()),
             InstanceType::Boolean => Term::Enum("Bool".into()),
@@ -43,8 +43,8 @@ impl AsPredicate for InstanceType {
     }
 }
 
-impl AsPredicate for &SingleOrVec<InstanceType> {
-    fn as_predicate(self) -> RichTerm {
+impl AsPredicate for SingleOrVec<InstanceType> {
+    fn as_predicate(&self) -> RichTerm {
         match self {
             SingleOrVec::Single(t) => t.as_predicate(),
             SingleOrVec::Vec(ts) => mk_app!(
@@ -58,9 +58,9 @@ impl AsPredicate for &SingleOrVec<InstanceType> {
     }
 }
 
-/// Convert a json schema Enum to a predicate. Enums are represented as &[Value].
-impl AsPredicate for &[Value] {
-    fn as_predicate(self) -> RichTerm {
+/// Convert a json schema Enum to a predicate. Enums are represented by `[Value]`s.
+impl AsPredicate for [Value] {
+    fn as_predicate(&self) -> RichTerm {
         mk_app!(
             static_access("predicates", ["enum"]),
             Term::Array(
@@ -75,9 +75,9 @@ impl AsPredicate for &[Value] {
     }
 }
 
-/// Convert a json schema Const to a predicate. Consts are represented as Values
-impl AsPredicate for &Value {
-    fn as_predicate(self) -> RichTerm {
+/// Convert a json schema Const to a predicate. Consts are represented by `Value`s
+impl AsPredicate for Value {
+    fn as_predicate(&self) -> RichTerm {
         Term::App(
             static_access("predicates", ["const"]),
             serde_json::from_value(self.clone()).unwrap(),
@@ -110,8 +110,8 @@ fn mk_any_of(schemas: impl IntoIterator<Item = RichTerm>) -> RichTerm {
     }
 }
 
-impl AsPredicates for &SubschemaValidation {
-    fn as_predicates(self) -> Vec<RichTerm> {
+impl AsPredicates for SubschemaValidation {
+    fn as_predicates(&self) -> Vec<RichTerm> {
         let SubschemaValidation {
             all_of,
             any_of,
@@ -171,8 +171,8 @@ impl AsPredicates for &SubschemaValidation {
     }
 }
 
-impl AsPredicates for &NumberValidation {
-    fn as_predicates(self) -> Vec<RichTerm> {
+impl AsPredicates for NumberValidation {
+    fn as_predicates(&self) -> Vec<RichTerm> {
         let NumberValidation {
             multiple_of,
             maximum,
@@ -209,8 +209,8 @@ impl AsPredicates for &NumberValidation {
     }
 }
 
-impl AsPredicates for &StringValidation {
-    fn as_predicates(self) -> Vec<RichTerm> {
+impl AsPredicates for StringValidation {
+    fn as_predicates(&self) -> Vec<RichTerm> {
         let StringValidation {
             max_length,
             min_length,
@@ -249,8 +249,8 @@ impl AsPredicates for &StringValidation {
     }
 }
 
-impl AsPredicates for &ArrayValidation {
-    fn as_predicates(self) -> Vec<RichTerm> {
+impl AsPredicates for ArrayValidation {
+    fn as_predicates(&self) -> Vec<RichTerm> {
         let ArrayValidation {
             items,
             additional_items,
@@ -331,8 +331,8 @@ impl AsPredicates for &ArrayValidation {
     }
 }
 
-impl AsPredicates for &ObjectValidation {
-    fn as_predicates(self) -> Vec<RichTerm> {
+impl AsPredicates for ObjectValidation {
+    fn as_predicates(&self) -> Vec<RichTerm> {
         let ObjectValidation {
             max_properties,
             min_properties,
@@ -451,8 +451,8 @@ fn dependencies(extensions: &BTreeMap<String, Value>) -> impl Iterator<Item = Ri
         .into_iter()
 }
 
-impl AsPredicate for &SchemaObject {
-    fn as_predicate(self) -> RichTerm {
+impl AsPredicate for SchemaObject {
+    fn as_predicate(&self) -> RichTerm {
         // NOTE: You may naively think that, for instance, numbers and strings are
         // mutually exclusive. Not to a json schema! Any number of these fields can
         // be set and the semantics is they get ANDed together, even if that can
@@ -495,8 +495,8 @@ impl AsPredicate for &SchemaObject {
     }
 }
 
-impl AsPredicate for &Schema {
-    fn as_predicate(self) -> RichTerm {
+impl AsPredicate for Schema {
+    fn as_predicate(&self) -> RichTerm {
         match self {
             Schema::Bool(true) => static_access("predicates", ["always"]),
             Schema::Bool(false) => static_access("predicates", ["never"]),

--- a/tests/json_schema_test_suite_test.rs
+++ b/tests/json_schema_test_suite_test.rs
@@ -2,7 +2,7 @@ use std::io::stderr;
 
 use json_schema_test_suite::{json_schema_test_suite, TestCase};
 use json_schema_to_nickel::{
-    definitions::Environment, predicates::AsPredicate, root_schema, wrap_predicate,
+    definitions::Environment, predicates::IntoPredicate, root_schema, wrap_predicate,
 };
 use nickel_lang_core::{eval::cache::lazy::CBNCache, program::Program, term::RichTerm};
 use schemars::schema::Schema;
@@ -38,7 +38,7 @@ fn translation_typecheck_test(
     } else {
         wrap_predicate(
             Environment::empty(),
-            dbg!(serde_json::from_value::<Schema>(test_case.schema).unwrap()).as_predicate(),
+            dbg!(serde_json::from_value::<Schema>(test_case.schema).unwrap()).into_predicate(),
         )
     };
 

--- a/tests/json_schema_test_suite_test.rs
+++ b/tests/json_schema_test_suite_test.rs
@@ -2,9 +2,10 @@ use std::io::stderr;
 
 use json_schema_test_suite::{json_schema_test_suite, TestCase};
 use json_schema_to_nickel::{
-    definitions::Environment, predicates::schema_to_predicate, root_schema, wrap_predicate,
+    definitions::Environment, predicates::AsPredicate, root_schema, wrap_predicate,
 };
 use nickel_lang_core::{eval::cache::lazy::CBNCache, program::Program, term::RichTerm};
+use schemars::schema::Schema;
 use stringreader::StringReader;
 
 #[json_schema_test_suite("vendor/JSON-Schema-Test-Suite", "draft7", {
@@ -37,7 +38,7 @@ fn translation_typecheck_test(
     } else {
         wrap_predicate(
             Environment::empty(),
-            schema_to_predicate(&dbg!(serde_json::from_value(test_case.schema).unwrap())),
+            dbg!(serde_json::from_value::<Schema>(test_case.schema).unwrap()).as_predicate(),
         )
     };
 

--- a/tests/json_schema_test_suite_test.rs
+++ b/tests/json_schema_test_suite_test.rs
@@ -2,7 +2,7 @@ use std::io::stderr;
 
 use json_schema_test_suite::{json_schema_test_suite, TestCase};
 use json_schema_to_nickel::{
-    definitions::Environment, predicates::IntoPredicate, root_schema, wrap_predicate,
+    definitions::Environment, predicates::AsPredicate, root_schema, wrap_predicate,
 };
 use nickel_lang_core::{eval::cache::lazy::CBNCache, program::Program, term::RichTerm};
 use schemars::schema::Schema;
@@ -38,7 +38,7 @@ fn translation_typecheck_test(
     } else {
         wrap_predicate(
             Environment::empty(),
-            dbg!(serde_json::from_value::<Schema>(test_case.schema).unwrap()).into_predicate(),
+            dbg!(serde_json::from_value::<Schema>(test_case.schema).unwrap()).as_predicate(),
         )
     };
 


### PR DESCRIPTION
We had a lot of functions that converted from various types to `RichTerm`, either producing a contract or a predicate. This change moves them all under a few traits.