### PR TITLE
Enum contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 [[package]]
 name = "nickel-lang-core"
 version = "0.1.0"
-source = "git+https://github.com/tweag/nickel?rev=refs/heads/master#c6e98d849e10d38fcc0d15f14809aae36fafa63f"
+source = "git+https://github.com/tweag/nickel?rev=refs/heads/master#396d8b384c4368b4948af5f408afd52183b1fc0b"
 dependencies = [
  "clap",
  "codespan",

--- a/examples/simple-schema/test.schema.json
+++ b/examples/simple-schema/test.schema.json
@@ -29,6 +29,14 @@
         null
       ]
     },
+    "my_reasonable_enum": {
+      "type": "string",
+      "enum": [
+        "foo",
+        "bar",
+        "baz"
+      ]
+    },
     "my_nullable_enum": {
       "anyOf": [
         {

--- a/lib/predicates.ncl
+++ b/lib/predicates.ncl
@@ -69,7 +69,7 @@
       `allOf preds` succeeds if all of the predicates in `preds` succeed
       Cf. [https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01#section-6.7.1]
     "%
-    = fun preds x =>
+   = fun preds x =>
       preds
       |> std.array.fold_right
         (
@@ -114,12 +114,15 @@
       `enum values x` succeeds if and only if `x` is equal to one of the elements of `values`.
       Cf. [https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01#section-6.1.2]
     "%
-    = fun values x =>
+    = let
+      checkEqual = fun input variant =>
+        input == variant || (std.is_enum input && (std.string.from_enum input == variant | Bool))
+    in fun values x =>
       values
       |> std.array.fold_right
         (
           fun value acc =>
-            if x == value then
+            if checkEqual x value then
               { success = true, error = "" }
             else
               acc

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -31,13 +31,14 @@ use nickel_lang_core::{
     label::Label,
     mk_app,
     term::{
-        make,
+        array::Array,
         record::{Field, FieldMetadata, RecordAttrs, RecordData},
         LabeledType, RichTerm, Term, TypeAnnotation,
     },
-    types::{TypeF, Types},
+    types::{EnumRows, EnumRowsF, RecordRows, TypeF, Types},
 };
 use schemars::schema::{InstanceType, ObjectValidation, Schema, SchemaObject, SingleOrVec};
+use serde_json::Value;
 
 use crate::{definitions, predicates::AsPredicate, utils::static_access};
 
@@ -48,109 +49,69 @@ fn only_ignored_fields<V>(extensions: &BTreeMap<String, V>) -> bool {
         .any(|x| !IGNORED_FIELDS.contains(&x.as_ref()))
 }
 
-/// Convert to a Nickel [`RichTerm`] representing a contract.
-pub trait AsContract {
-    fn as_contract(&self) -> RichTerm;
+/// [`Contract`] Represents the set of contracts that would be applied to a
+/// value. This can be empty or many as in `a` or `a | Foo | Bar`, but this
+/// list can also be converted to a single value using `predicates.always` and
+/// std.contract.Sequence
+#[derive(Clone)]
+pub struct Contract(Vec<RichTerm>);
+
+impl From<RichTerm> for Contract {
+    fn from(rt: RichTerm) -> Self {
+        Contract(vec![rt])
+    }
 }
 
-/// Convert to a Nickel [`RichTerm`] representing a contract, if possible.
-pub trait TryAsContract {
-    fn try_as_contract(&self) -> Option<RichTerm>;
+impl From<Contract> for RichTerm {
+    fn from(Contract(c): Contract) -> Self {
+        match c.as_slice() {
+            [] => Schema::Bool(true).as_predicate(),
+            // TODO: shouldn't need to clone here
+            [rt] => rt.clone(),
+            _ => {
+                let arr = Term::Array(Array::new(c.into_iter().collect()), Default::default());
+                mk_app!(static_access("std", ["contract", "Sequence"]), arr)
+            }
+        }
+    }
 }
 
-/// Convert to a Nickel [`LabeledType`]
-pub trait AsLabeledType {
-    fn as_labeled_type(&self) -> LabeledType;
+impl From<Term> for Contract {
+    fn from(value: Term) -> Self {
+        Contract::from(RichTerm::from(value))
+    }
 }
 
-/// Convert to a Nickel [`LabeledType`], if possible.
-pub trait TryAsLabeledType {
-    fn try_as_labeled_type(&self) -> Option<LabeledType>;
+impl From<TypeF<Box<Types>, RecordRows, EnumRows>> for Contract {
+    fn from(value: TypeF<Box<Types>, RecordRows, EnumRows>) -> Self {
+        Contract::from(Term::Types(Types::from(value)))
+    }
 }
 
-/// Convert an [`InstanceType`] into a Nickel [`RichTerm`]. We're in a bit of a
-/// bind here. When types appear in term position, they are parsed immediately
-/// into another form (built-in contracts like `$bool`). These contracts would
-/// get pretty-printed as-is (`$bool`), but `$`-identifiers are **only** valid
-/// when generated internally in Nickel; the parser does not understand them.
-/// In other words, the way types in term position are represented internally
-/// cannot be pretty printed and parsed again. So here we use `Term::Var`. If
-/// we passed this directly to Nickel as a `RichTerm`, it would be an error,
-/// but the pretty printer not understanding that builtin type names are not
-/// valid identifiers.
-impl AsContract for InstanceType {
-    fn as_contract(&self) -> RichTerm {
-        match self {
+impl From<&InstanceType> for Contract {
+    fn from(value: &InstanceType) -> Contract {
+        match value {
             InstanceType::Null => contract_from_predicate(mk_app!(
                 static_access("predicates", ["isType"]),
                 Term::Enum("Null".into())
             )),
-            InstanceType::Boolean => make::var("Bool"),
-            InstanceType::Object => Term::Record(RecordData {
+            InstanceType::Boolean => Contract::from(TypeF::Bool),
+            InstanceType::Object => Contract::from(Term::Record(RecordData {
                 attrs: RecordAttrs { open: true },
                 ..Default::default()
-            })
-            .into(),
-            InstanceType::Array => mk_app!(make::var("Array"), make::var("Dyn")),
-            InstanceType::Number => make::var("Number"),
-            InstanceType::String => make::var("String"),
-            InstanceType::Integer => static_access("std", ["number", "Integer"]),
+            })),
+            InstanceType::Array => Contract::from(TypeF::Array(Box::new(TypeF::Dyn.into()))),
+            InstanceType::Number => Contract::from(TypeF::Number),
+            InstanceType::String => Contract::from(TypeF::String),
+            InstanceType::Integer => Contract::from(static_access("std", ["number", "Integer"])),
         }
     }
 }
 
-impl AsLabeledType for InstanceType {
-    fn as_labeled_type(&self) -> LabeledType {
-        let types = match self {
-            InstanceType::Boolean => TypeF::Bool.into(),
-            InstanceType::Array => TypeF::Array(Box::new(Types::from(TypeF::Dyn))).into(),
-            InstanceType::Number => TypeF::Number.into(),
-            InstanceType::String => TypeF::String.into(),
-            InstanceType::Null | InstanceType::Object | InstanceType::Integer => {
-                TypeF::Flat(self.as_contract()).into()
-            }
-        };
-        LabeledType {
-            types,
-            label: Label::dummy(),
-        }
-    }
-}
+impl TryFrom<&ObjectValidation> for Contract {
+    type Error = ();
 
-impl TryAsLabeledType for SchemaObject {
-    fn try_as_labeled_type(&self) -> Option<LabeledType> {
-        match self {
-            SchemaObject {
-                metadata: _,
-                instance_type: Some(SingleOrVec::Single(instance_type)),
-                format: _,
-                enum_values: None,
-                const_value: None,
-                subschemas: None,
-                number: None,
-                string: None,
-                array: None,
-                object: None,
-                reference: None, /* TODO(vkleen): We should be able to relax this once we
-                                  * properly track references */
-                extensions,
-            } if only_ignored_fields(extensions) => Some(instance_type.as_labeled_type()),
-            _ => None,
-        }
-    }
-}
-
-impl TryAsLabeledType for Schema {
-    fn try_as_labeled_type(&self) -> Option<LabeledType> {
-        match self {
-            Schema::Bool(_) => None,
-            Schema::Object(obj) => obj.try_as_labeled_type(),
-        }
-    }
-}
-
-impl TryAsContract for ObjectValidation {
-    fn try_as_contract(&self) -> Option<RichTerm> {
+    fn try_from(value: &ObjectValidation) -> Result<Self, Self::Error> {
         fn is_open_record(additional: Option<&Schema>) -> bool {
             match additional {
                 Some(Schema::Bool(open)) => *open,
@@ -163,7 +124,7 @@ impl TryAsContract for ObjectValidation {
         // `additional_properties` as a separate pattern
         // SEE: https://github.com/rust-lang/rust/issues/29641
         // SEE: https://github.com/rust-lang/rust/issues/87121
-        match (self, self.additional_properties.as_deref()) {
+        match (value, value.additional_properties.as_deref()) {
             (
                 ObjectValidation {
                     max_properties: None,
@@ -175,19 +136,42 @@ impl TryAsContract for ObjectValidation {
                     property_names: None,
                 },
                 None | Some(Schema::Bool(_)),
-            ) if pattern_properties.is_empty() => Some(generate_record_contract(
+            ) if pattern_properties.is_empty() => Ok(Contract::from(generate_record_contract(
                 required,
                 properties,
                 is_open_record(additional_properties.as_deref()),
-            )),
-            _ => None,
+            ))),
+            _ => Err(()),
         }
     }
 }
 
-impl TryAsContract for SchemaObject {
-    fn try_as_contract(&self) -> Option<RichTerm> {
-        match self {
+impl TryFrom<&SchemaObject> for Contract {
+    type Error = ();
+
+    fn try_from(value: &SchemaObject) -> Result<Self, Self::Error> {
+        match value {
+            // a raw type
+            SchemaObject {
+                metadata: _,
+                instance_type: Some(SingleOrVec::Single(instance_type)),
+                format: _,
+                enum_values: None,
+                const_value: None,
+                subschemas: None,
+                number: None,
+                string: None,
+                array: None,
+                object: None,
+                reference: None,
+                extensions,
+            } if only_ignored_fields(extensions) => {
+                // We ultimately produce a Flat type based on a contract with
+                // only a type in it. Semantically, this is kind of weird. But
+                // the pretty printer doesn't care, and it simplifies our code
+                // significantly.
+                Ok(Contract::from(instance_type.as_ref()))
+            }
             // a reference to a definition
             SchemaObject {
                 metadata: _,
@@ -203,7 +187,7 @@ impl TryAsContract for SchemaObject {
                 reference: Some(reference),
                 extensions,
             } if only_ignored_fields(extensions) => {
-                Some(definitions::reference(reference).contract)
+                Ok(Contract::from(definitions::reference(reference).contract))
             }
             // a freeform record
             SchemaObject {
@@ -219,14 +203,11 @@ impl TryAsContract for SchemaObject {
                 object: None,
                 reference: None,
                 extensions,
-            } if only_ignored_fields(extensions) && **instance_type == InstanceType::Object => {
-                Some(
-                    Term::Record(RecordData {
-                        attrs: RecordAttrs { open: true },
-                        ..Default::default()
-                    })
-                    .into(),
-                )
+            } if **instance_type == InstanceType::Object && only_ignored_fields(extensions) => {
+                Ok(Contract::from(Term::Record(RecordData {
+                    attrs: RecordAttrs { open: true },
+                    ..Default::default()
+                })))
             }
             // a record with sub-field types specified
             SchemaObject {
@@ -242,29 +223,69 @@ impl TryAsContract for SchemaObject {
                 object: Some(ov),
                 reference: None,
                 extensions,
-            } if only_ignored_fields(extensions) && **instance_type == InstanceType::Object => {
-                ov.as_ref().try_as_contract()
+            } if **instance_type == InstanceType::Object && only_ignored_fields(extensions) => {
+                ov.as_ref().try_into()
             }
-            _ => None,
+            // Enum contract with all strings
+            // => | std.enum.TagOrString | [| 'foo, 'bar, 'baz |]
+            SchemaObject {
+                metadata: _,
+                instance_type: Some(SingleOrVec::Single(instance_type)),
+                format: None,
+                enum_values: Some(values),
+                const_value: None,
+                subschemas: None,
+                number: None,
+                string: None,
+                array: None,
+                object: None,
+                reference: None,
+                extensions: _,
+            } if **instance_type == InstanceType::String => {
+                let enum_rows: EnumRows =
+                    values
+                        .iter()
+                        .fold(Ok(EnumRows(EnumRowsF::Empty)), |acc, value| {
+                            let id = match value {
+                                Value::String(s) => s.into(),
+                                _ => return Err(()),
+                            };
+                            Ok(EnumRows(EnumRowsF::Extend {
+                                row: id,
+                                tail: Box::new(acc?),
+                            }))
+                        })?;
+                Ok(Contract(vec![
+                    static_access("std", ["enum", "TagOrString"]),
+                    Term::Types(TypeF::Enum(enum_rows).into()).into(),
+                ]))
+            }
+            _ => Err(()),
         }
     }
 }
 
-impl TryAsContract for Schema {
-    fn try_as_contract(&self) -> Option<RichTerm> {
-        match self {
-            Schema::Bool(_) => None,
-            Schema::Object(obj) => obj.try_as_contract(),
+impl TryFrom<&Schema> for Contract {
+    type Error = ();
+
+    fn try_from(value: &Schema) -> Result<Self, Self::Error> {
+        match value {
+            Schema::Bool(true) => Ok(Contract(vec![])),
+            Schema::Bool(false) => Err(()),
+            Schema::Object(obj) => obj.try_into(),
         }
     }
 }
 
-impl AsLabeledType for RichTerm {
-    fn as_labeled_type(&self) -> LabeledType {
-        LabeledType {
-            types: TypeF::Flat(self.clone()).into(),
-            label: Label::dummy(),
-        }
+impl From<Contract> for Vec<LabeledType> {
+    fn from(Contract(value): Contract) -> Self {
+        value
+            .into_iter()
+            .map(|rt| LabeledType {
+                types: TypeF::Flat(rt).into(),
+                label: Label::dummy(),
+            })
+            .collect()
     }
 }
 
@@ -307,16 +328,12 @@ fn generate_record_contract(
     open: bool,
 ) -> RichTerm {
     let fields = properties.iter().map(|(name, schema)| {
-        let contracts = if let Schema::Bool(true) = schema {
-            // record fields where anything is allowed should look like
-            // { a, b } not { a | predicates.always, b | predicates.always }
-            vec![]
-        } else if let Some(t) = schema.try_as_labeled_type() {
-            vec![t]
-        } else if let Some(term) = schema.try_as_contract() {
-            vec![term.as_labeled_type()]
+        // try to convert to a contract, otherwise convert the predicate version
+        // to a contract
+        let contract = if let Ok(c) = Contract::try_from(schema) {
+            c
         } else {
-            vec![contract_from_predicate(schema.as_predicate()).as_labeled_type()]
+            contract_from_predicate(schema.as_predicate())
         };
         (
             name.into(),
@@ -324,7 +341,7 @@ fn generate_record_contract(
                 metadata: FieldMetadata {
                     annotation: TypeAnnotation {
                         types: None,
-                        contracts,
+                        contracts: contract.into(),
                     },
                     opt: !required.contains(name),
                     doc: Documentation::try_from(schema).map(String::from).ok(),
@@ -344,9 +361,10 @@ fn generate_record_contract(
 
 /// Convert `predicate` into a contract, suitable for use in a contract
 /// assertion `term | Contract`.
-pub fn contract_from_predicate(predicate: RichTerm) -> RichTerm {
+pub fn contract_from_predicate(predicate: RichTerm) -> Contract {
     mk_app!(
         static_access("predicates", ["contract_from_predicate"]),
         predicate
     )
+    .into()
 }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -20,14 +20,14 @@ use schemars::schema::Schema;
 
 use crate::{
     contracts::{contract_from_predicate, Contract},
-    predicates::AsPredicate,
+    predicates::Predicate,
     utils::static_access,
 };
 
 /// The nickel predicate and contract generated for a schema.
 #[derive(Clone)]
 pub struct ConvertedSchema {
-    predicate: RichTerm,
+    predicate: Predicate,
     contract: Contract,
 }
 
@@ -77,7 +77,7 @@ impl Environment {
         let predicates = self
             .0
             .into_iter()
-            .map(|(k, v)| (Ident::from(k), v.predicate))
+            .map(|(k, v)| (Ident::from(k), v.predicate.into()))
             .collect();
         Term::Let(
             "definitions".into(),
@@ -115,13 +115,13 @@ impl From<&BTreeMap<String, Schema>> for Environment {
         let terms = defs
             .iter()
             .map(|(name, schema)| {
-                let predicate = schema.as_predicate();
+                let predicate = Predicate::from(schema);
                 (
                     name.clone(),
                     ConvertedSchema {
-                        contract: Contract::try_from(schema)
-                            .unwrap_or_else(|()| contract_from_predicate(access(name).predicate))
-                            .into(),
+                        contract: Contract::try_from(schema).unwrap_or_else(|()| {
+                            contract_from_predicate(Predicate::from(access(name).predicate))
+                        }),
                         predicate,
                     },
                 )

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -19,7 +19,7 @@ use nickel_lang_core::{
 use schemars::schema::Schema;
 
 use crate::{
-    contracts::{contract_from_predicate, TryAsContract},
+    contracts::{contract_from_predicate, Contract},
     predicates::AsPredicate,
     utils::static_access,
 };
@@ -28,7 +28,7 @@ use crate::{
 #[derive(Clone)]
 pub struct ConvertedSchema {
     predicate: RichTerm,
-    contract: RichTerm,
+    contract: Contract,
 }
 
 /// The field access for referencing the predicate or contract generated from a
@@ -72,7 +72,7 @@ impl Environment {
         let contracts = self
             .0
             .iter()
-            .map(|(k, v)| (Ident::from(k), v.contract.clone()))
+            .map(|(k, v)| (Ident::from(k), v.contract.clone().into()))
             .collect();
         let predicates = self
             .0
@@ -119,9 +119,9 @@ impl From<&BTreeMap<String, Schema>> for Environment {
                 (
                     name.clone(),
                     ConvertedSchema {
-                        contract: schema
-                            .try_as_contract()
-                            .unwrap_or_else(|| contract_from_predicate(access(name).predicate)),
+                        contract: Contract::try_from(schema)
+                            .unwrap_or_else(|()| contract_from_predicate(access(name).predicate))
+                            .into(),
                         predicate,
                     },
                 )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub(crate) mod utils;
 use contracts::{contract_from_predicate, Contract};
 use definitions::Environment;
 use nickel_lang_core::term::{RichTerm, Term};
-use predicates::AsPredicate;
+use predicates::Predicate;
 use schemars::schema::RootSchema;
 
 /// Convert a [`RootSchema`] into a Nickel contract. If the JSON schema is
@@ -38,7 +38,7 @@ pub fn root_schema(root: &RootSchema) -> RichTerm {
     if let Ok(contract) = Contract::try_from(&root.schema) {
         wrap_contract(env, contract)
     } else {
-        let predicate = root.schema.as_predicate();
+        let predicate = Predicate::from(&root.schema);
         wrap_predicate(env, predicate)
     }
 }
@@ -56,6 +56,6 @@ pub fn wrap_contract(env: Environment, contract: Contract) -> RichTerm {
 }
 
 /// Convert a predicate into a contract and then wrap it using `wrap_contract`.
-pub fn wrap_predicate(env: Environment, predicate: RichTerm) -> RichTerm {
+pub fn wrap_predicate(env: Environment, predicate: Predicate) -> RichTerm {
     wrap_contract(env, contract_from_predicate(predicate))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod definitions;
 pub mod predicates;
 pub(crate) mod utils;
 
-use contracts::{contract_from_predicate, TryAsContract};
+use contracts::{contract_from_predicate, Contract};
 use definitions::Environment;
 use nickel_lang_core::term::{RichTerm, Term};
 use predicates::AsPredicate;
@@ -35,7 +35,7 @@ use schemars::schema::RootSchema;
 /// Otherwise, we fall back to generating a predicate.
 pub fn root_schema(root: &RootSchema) -> RichTerm {
     let env = Environment::from(&root.definitions);
-    if let Some(contract) = root.schema.try_as_contract() {
+    if let Ok(contract) = Contract::try_from(&root.schema) {
         wrap_contract(env, contract)
     } else {
         let predicate = root.schema.as_predicate();
@@ -45,11 +45,11 @@ pub fn root_schema(root: &RootSchema) -> RichTerm {
 
 /// Wrap a Nickel contract making use of the predicates support library and
 /// recursive definitions recorded in `env`.
-pub fn wrap_contract(env: Environment, contract: RichTerm) -> RichTerm {
+pub fn wrap_contract(env: Environment, contract: Contract) -> RichTerm {
     Term::Let(
         "predicates".into(),
         Term::Import("./lib/predicates.ncl".into()).into(),
-        env.wrap(contract),
+        env.wrap(contract.into()),
         Default::default(),
     )
     .into()

--- a/tests/json_schema_test_suite_test.rs
+++ b/tests/json_schema_test_suite_test.rs
@@ -2,7 +2,7 @@ use std::io::stderr;
 
 use json_schema_test_suite::{json_schema_test_suite, TestCase};
 use json_schema_to_nickel::{
-    definitions::Environment, predicates::AsPredicate, root_schema, wrap_predicate,
+    definitions::Environment, predicates::Predicate, root_schema, wrap_predicate,
 };
 use nickel_lang_core::{eval::cache::lazy::CBNCache, program::Program, term::RichTerm};
 use schemars::schema::Schema;
@@ -38,7 +38,9 @@ fn translation_typecheck_test(
     } else {
         wrap_predicate(
             Environment::empty(),
-            dbg!(serde_json::from_value::<Schema>(test_case.schema).unwrap()).as_predicate(),
+            Predicate::from(dbg!(
+                &serde_json::from_value::<Schema>(test_case.schema).unwrap()
+            )),
         )
     };
 


### PR DESCRIPTION
Adds a contract for simple enums (all strings).

This allows more contracts to be turned into pure contracts (rather than predicates). When that happens, the LSP will be able to give the user completion on variants.
In addition, we refactored some of the trait implementations and created newtypes for Contracts and Predicates to support it, but also because having everything be RichTerms gets confusing.