### PR TITLE
Fix interpolation and quoting in predicate error messages

### DIFF
--- a/lib/records.ncl
+++ b/lib/records.ncl
@@ -73,7 +73,7 @@
                   else
                     let result = value x."%{field}" in
                     if !result.success then
-                      { success = false, error = m%%"field "%{field}" didn't validate: %{result.error}"%%, checked : { _ : Bool } = {} }
+                      { success = false, error = m%"field `%{field}` didn't validate: %{result.error}"%, checked : { _ : Bool } = {} }
                     else
                       { success = acc.success, error = acc.error, checked = std.record.insert field true acc.checked }
               )
@@ -108,7 +108,7 @@
                         fun { field, value } acc =>
                           let result = pred value in
                           if !result.success then
-                            { success = false, error = m%%"field "%{field}" didn't validate: %{result.error}"%%, checked : { _ : Bool } = {} }
+                            { success = false, error = m%"field `%{field}` didn't validate: %{result.error}"%, checked : { _ : Bool } = {} }
                           else
                             { success = acc.success, error = acc.error, checked = std.record.insert field true acc.checked }
                       )
@@ -158,7 +158,7 @@
                   fun { field, value } acc =>
                     let result = additionalProperties value in
                     if !result.success then
-                      { success = false, error = m%%"field "%{field}" didn't validate: %{result.error}"%% }
+                      { success = false, error = m%"field `%{field}` didn't validate: %{result.error}"% }
                     else
                       acc
                 )


### PR DESCRIPTION
When the Nickel lexer was changed to parse `"%"` as a string ending delimiter even when a `{` follows, I naively changed some string delimiters to `m%%`. However, @thufschmitt correctly observed that this way no interpolation will take place. This PR is a copout: I just use backticks instead of double quotes and reintroduce the single-percent delimiters.