### PR TITLE
Read stdin if schema path is missing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,9 @@
-use std::{error::Error, fs::File, io::stdout, path::PathBuf};
+use std::{
+    error::Error,
+    fs::File,
+    io::{stdout, Read},
+    path::PathBuf,
+};
 
 use clap::Parser;
 use json_schema_to_nickel::root_schema;
@@ -9,11 +14,17 @@ use terminal_size::{terminal_size, Width};
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
+    /// Path to a JSON schema file, or "-" to read the schema file from stdin.
     schema: String,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let f = File::open(PathBuf::from(Args::parse().schema))?;
+    let args = Args::parse();
+    let f: Box<dyn Read> = if args.schema == "-" {
+        Box::new(std::io::stdin())
+    } else {
+        Box::new(File::open(PathBuf::from(args.schema))?)
+    };
     let schema: RootSchema = serde_json::from_reader(f)?;
 
     let size = terminal_size()

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use std::{
     error::Error,
     fs::File,
     io::{stdout, Read},
-    path::PathBuf,
 };
 
 use clap::Parser;
@@ -14,17 +13,18 @@ use terminal_size::{terminal_size, Width};
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Path to a JSON schema file, or "-" to read the schema file from stdin.
-    schema: String,
+    /// Path to a JSON schema file. If omitted, the schema file will be read from stdin.
+    schema: Option<String>,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
-    let f: Box<dyn Read> = if args.schema == "-" {
-        Box::new(std::io::stdin())
+    let f: Box<dyn Read> = if let Some(path) = args.schema {
+        Box::new(File::open(path)?)
     } else {
-        Box::new(File::open(PathBuf::from(args.schema))?)
+        Box::new(std::io::stdin())
     };
+
     let schema: RootSchema = serde_json::from_reader(f)?;
 
     let size = terminal_size()


### PR DESCRIPTION
I'd like to use json-schema-to-nickel without writing out the schema to a file first. This patch interprets a file named "-" as stdin, so you can do `cat blah.json | json-schema-to-nickel -`

I'm never quite sure about the best UI for this -- another reasonable option is to make the file optional and default to stdin...