### PR TITLE
Don't panic on external refs

### DIFF
--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -18,6 +18,7 @@ use nickel_lang_core::{
         record::{Field, FieldMetadata, RecordData},
         LetAttrs, RichTerm, Term,
     },
+    typ::TypeF,
 };
 use schemars::schema::Schema;
 
@@ -59,7 +60,17 @@ pub fn reference(reference: &str) -> Access {
     if let Some(remainder) = reference.strip_prefix("#/definitions/") {
         access(remainder)
     } else {
-        unimplemented!()
+        eprintln!(
+            "
+            Warning: skipping reference {reference} (replaced by an always succeeding `Dyn` \
+            contract). The current version of `json-schema-to-nickel` doesn't support external \
+            references"
+        );
+
+        Access {
+            contract: Term::Type(TypeF::Dyn.into()).into(),
+            predicate: static_access("definitions", ["predicate", "always"]),
+        }
     }
 }
 


### PR DESCRIPTION
Closes #48.

Using external schemas as references is not supported by the current version of json-schema-to-nickel. The previous implemented just panicked, which is unfortunate as it's an all-or-nothing approach: if there's a ref somewhere in a schema, you just can't do anything with it.

This commit adopts a middle ground by warning about unfollowed external refs, and substitute them for `Dyn` contracts.