### PR TITLE
Fix wrong predicate for external refs

### DIFF
--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -69,7 +69,7 @@ pub fn reference(reference: &str) -> Access {
 
         Access {
             contract: Term::Type(TypeF::Dyn.into()).into(),
-            predicate: static_access("definitions", ["predicate", "always"]),
+            predicate: static_access("predicates", ["always"]),
         }
     }
 }


### PR DESCRIPTION
External refs are now replaced with `Dyn` contract since #70. The corresponding predicate is `predicates.always`. We were incorrectly using `definitions.predicate.always` instead, which might not even be defined - definitions are specific to each JSON schema.