### PR TITLE
Extended local ref support

### DIFF
--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -335,7 +335,7 @@ impl From<RichTerm> for Contract {
 impl From<Contract> for RichTerm {
     fn from(Contract(c): Contract) -> Self {
         match c.as_slice() {
-            [] => static_access(PREDICATES_LIBRARY, ["always"]).into(),
+            [] => static_access(PREDICATES_LIBRARY, ["always"]),
             // TODO: shouldn't need to clone here
             [rt] => rt.clone(),
             _ => {

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -90,7 +90,7 @@ pub trait TryAsContract {
     /// component couldn't be converted to a lazy contract, and thus requires to go through a
     /// predicate.
     ///
-    /// `try_convert` will record the references used during the conversion through the `refs_usage` parameter.
+    /// `try_as_contract` will record the references used during the conversion through the `refs_usage` parameter.
     fn try_as_contract(&self, refs_usage: &mut RefsUsage) -> Option<Contract>;
 }
 

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -1,9 +1,8 @@
-//! # Nickel contract generation for certain JSON schemas
+//! # Nickel contract generation for JSON schemas
 //!
-//! Since generating lazy Nickel contracts for arbitrary JSON schemas is
-//! impossible, this module restricts itself to generating record contracts for
-//! JSON schemas that are simple enough. A JSON schema can be successfully
-//! turned into a record contract if it takes the form
+//! Since generating lazy Nickel contracts for arbitrary JSON schemas is impossible, this module
+//! restricts itself to generating record contracts for JSON schemas that are simple enough. A JSON
+//! schema can be successfully turned into a record contract if it takes the form
 //!
 //! ```json
 //! {
@@ -25,6 +24,8 @@
 //! ```
 //!
 //! is turned into the Nickel type `Bool`.
+use crate::definitions::RefUsage;
+use schemars::schema::RootSchema;
 use std::collections::{BTreeMap, BTreeSet};
 
 use nickel_lang_core::{
@@ -42,7 +43,11 @@ use schemars::schema::{
 };
 use serde_json::Value;
 
-use crate::{definitions, predicates::Predicate, utils::static_access};
+use crate::{
+    definitions::{self, RefsUsage},
+    predicates::{Convert, Predicate},
+    utils::static_access,
+};
 
 fn only_ignored_fields<V>(extensions: &BTreeMap<String, V>) -> bool {
     const IGNORED_FIELDS: &[&str] = &["$comment"];
@@ -58,6 +63,263 @@ fn only_ignored_fields<V>(extensions: &BTreeMap<String, V>) -> bool {
 #[derive(Clone)]
 pub struct Contract(Vec<RichTerm>);
 
+// The whole conversion starts from a root schema with the inial empty state: thus we don't
+// implement `TryConvert<RootSchema>` but `TryFrom<RootSchema>` directly.
+impl TryFrom<RootSchema> for Contract {
+    type Error = ();
+
+    fn try_from(value: RootSchema) -> Result<Self, Self::Error> {
+        Contract::try_convert(&value.schema, &mut RefsUsage::new()).ok_or(())
+    }
+}
+
+/// [TryConvert] is essentially like `TryFrom` but passes additional state around used for
+/// effective reference resolution.
+pub trait TryConvert<F> {
+    /// Try to convert a root JSON schema to a contract. Returns `None` if the schema couldn't be
+    /// converted to a lazy contract, and thus requires to go through a predicate.
+    ///
+    /// [Self::try_convert] carries additional state related to reference resolution.
+    fn try_convert(from: &F, refs_usage: &mut RefsUsage) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+pub trait ConvertThruPred<F> {
+    /// Convert a JSON schema to a contract by first converting it to a predicate, and then use
+    /// json-schema-to-nickel's `from_predicate` helper. As opposed to [TryConvert::try_convert],
+    /// this conversion can't fail. However, it is less desirable (as it throws lazyness out of the
+    /// window and is less LSP-friendly for e.g. completion), so we generally try to use
+    /// `TryConvert::try_convert` first.
+    fn convert_thru_pred(from: &F, refs_usage: &mut RefsUsage) -> Self
+    where
+        Self: Sized;
+}
+
+impl<F> ConvertThruPred<F> for Contract
+where
+    Predicate: Convert<F>,
+{
+    fn convert_thru_pred(from: &F, refs_usage: &mut RefsUsage) -> Self {
+        Contract::from(Predicate::convert(from, refs_usage))
+    }
+}
+
+impl TryConvert<Schema> for Contract {
+    fn try_convert(from: &Schema, refs_usage: &mut RefsUsage) -> Option<Self> {
+        match from {
+            Schema::Bool(true) => Some(Contract(vec![])),
+            Schema::Bool(false) => None,
+            Schema::Object(obj) => Contract::try_convert(obj, refs_usage),
+        }
+    }
+}
+
+impl TryConvert<SchemaObject> for Contract {
+    fn try_convert(from: &SchemaObject, refs_usage: &mut RefsUsage) -> Option<Self> {
+        match from {
+            // a raw type
+            SchemaObject {
+                metadata: _,
+                instance_type: Some(SingleOrVec::Single(instance_type)),
+                format: _,
+                enum_values: None,
+                const_value: None,
+                subschemas: None,
+                number: None,
+                string: None,
+                array: None,
+                object: None,
+                reference: None,
+                extensions,
+            } if only_ignored_fields(extensions) => {
+                // We ultimately produce a Flat type based on a contract with
+                // only a type in it. Semantically, this is kind of weird. But
+                // the pretty printer doesn't care, and it simplifies our code
+                // significantly.
+                Some(Contract::from(instance_type.as_ref()))
+            }
+            // a reference to a definition
+            SchemaObject {
+                metadata: _,
+                instance_type: None,
+                format: None,
+                enum_values: None,
+                const_value: None,
+                subschemas: None,
+                number: None,
+                string: None,
+                array: None,
+                object: None,
+                reference: Some(reference),
+                extensions,
+            } if only_ignored_fields(extensions) => Some(Contract::from(definitions::resolve_ref(
+                reference,
+                refs_usage,
+                RefUsage::Contract,
+            ))),
+            // a freeform record
+            SchemaObject {
+                metadata: _,
+                instance_type: Some(SingleOrVec::Single(instance_type)),
+                format: None,
+                enum_values: None,
+                const_value: None,
+                subschemas: None,
+                number: None,
+                string: None,
+                array: None,
+                object: None,
+                reference: None,
+                extensions,
+            } if **instance_type == InstanceType::Object && only_ignored_fields(extensions) => {
+                Some(Contract::from(Term::Record(RecordData {
+                    attrs: RecordAttrs { open: true },
+                    ..Default::default()
+                })))
+            }
+            // a record with sub-field types specified
+            SchemaObject {
+                metadata: _,
+                instance_type: Some(SingleOrVec::Single(instance_type)),
+                format: None,
+                enum_values: None,
+                const_value: None,
+                subschemas: None,
+                number: None,
+                string: None,
+                array: None,
+                object: Some(ov),
+                reference: None,
+                extensions,
+            } if **instance_type == InstanceType::Object && only_ignored_fields(extensions) => {
+                Contract::try_convert(ov.as_ref(), refs_usage)
+            }
+            // Enum contract with all strings
+            // => | std.enum.TagOrString | [| 'foo, 'bar, 'baz |]
+            SchemaObject {
+                metadata: _,
+                instance_type: Some(SingleOrVec::Single(instance_type)),
+                format: None,
+                enum_values: Some(values),
+                const_value: None,
+                subschemas: None,
+                number: None,
+                string: None,
+                array: None,
+                object: None,
+                reference: None,
+                extensions: _,
+            } if **instance_type == InstanceType::String => {
+                let enum_rows: EnumRows =
+                    values
+                        .iter()
+                        .try_fold(EnumRows(EnumRowsF::Empty), |acc, value| {
+                            let id = match value {
+                                Value::String(s) => s.into(),
+                                _ => return None,
+                            };
+                            Some(EnumRows(EnumRowsF::Extend {
+                                row: id,
+                                tail: Box::new(acc),
+                            }))
+                        })?;
+                Some(Contract(vec![
+                    static_access("std", ["enum", "TagOrString"]),
+                    Term::Type(TypeF::Enum(enum_rows).into()).into(),
+                ]))
+            }
+            SchemaObject {
+                metadata: _,
+                instance_type: Some(SingleOrVec::Single(instance_type)),
+                format: None,
+                enum_values: None,
+                const_value: None,
+                subschemas: None,
+                number: None,
+                string: None,
+                array: Some(av),
+                object: None,
+                reference: None,
+                extensions: _,
+            } if **instance_type == InstanceType::Array => {
+                Contract::try_convert(av.as_ref(), refs_usage)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl TryConvert<ObjectValidation> for Contract {
+    fn try_convert(from: &ObjectValidation, refs_usage: &mut RefsUsage) -> Option<Self> {
+        fn is_open_record(additional: Option<&Schema>) -> bool {
+            match additional {
+                Some(Schema::Bool(open)) => *open,
+                None => true,
+                _ => unreachable!("additional_properties must be checked beforehand"),
+            }
+        }
+
+        // box / deref patterns aren't stabilized, so we have to separate out
+        // `additional_properties` as a separate pattern
+        // SEE: https://github.com/rust-lang/rust/issues/29641
+        // SEE: https://github.com/rust-lang/rust/issues/87121
+        match (from, from.additional_properties.as_deref()) {
+            (
+                ObjectValidation {
+                    max_properties: None,
+                    min_properties: None,
+                    required,
+                    properties,
+                    pattern_properties,
+                    additional_properties,
+                    property_names: None,
+                },
+                None | Some(Schema::Bool(_)),
+            ) if pattern_properties.is_empty() => Some(Contract::from(generate_record_contract(
+                required,
+                properties,
+                is_open_record(additional_properties.as_deref()),
+                refs_usage,
+            ))),
+            _ => None,
+        }
+    }
+}
+
+impl TryConvert<ArrayValidation> for Contract {
+    fn try_convert(from: &ArrayValidation, refs_usage: &mut RefsUsage) -> Option<Self> {
+        if let ArrayValidation {
+            items: Some(SingleOrVec::Single(s)),
+            additional_items: None,
+            max_items: None,
+            min_items: None,
+            unique_items: None,
+            contains: None,
+        } = from
+        {
+            let elt = Contract::try_convert(s.as_ref(), refs_usage)
+                .unwrap_or_else(|| Contract::convert_thru_pred(s.as_ref(), refs_usage));
+            if let [elt] = elt.0.as_slice() {
+                Some(Contract::from(TypeF::Array(Box::new(
+                    TypeF::Flat(elt.clone()).into(),
+                ))))
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
+// The following conversions:
+//
+// 1. Are infallible
+// 2. Don't do reference resolution
+//
+// We implement `From` directly instead of `TryConvert`.
+
 impl From<RichTerm> for Contract {
     fn from(rt: RichTerm) -> Self {
         Contract(vec![rt])
@@ -67,7 +329,7 @@ impl From<RichTerm> for Contract {
 impl From<Contract> for RichTerm {
     fn from(Contract(c): Contract) -> Self {
         match c.as_slice() {
-            [] => Predicate::from(&Schema::Bool(true)).into(),
+            [] => static_access("predicates", ["always"]).into(),
             // TODO: shouldn't need to clone here
             [rt] => rt.clone(),
             _ => {
@@ -93,13 +355,10 @@ impl From<TypeF<Box<Type>, RecordRows, EnumRows>> for Contract {
 impl From<&InstanceType> for Contract {
     fn from(value: &InstanceType) -> Contract {
         match value {
-            InstanceType::Null => contract_from_predicate(
-                mk_app!(
-                    static_access("predicates", ["isType"]),
-                    Term::Enum("Null".into())
-                )
-                .into(),
-            ),
+            InstanceType::Null => Contract::from(Predicate::from(mk_app!(
+                static_access("predicates", ["isType"]),
+                Term::Enum("Null".into())
+            ))),
             InstanceType::Boolean => Contract::from(TypeF::Bool),
             InstanceType::Object => Contract::from(Term::Record(RecordData {
                 attrs: RecordAttrs { open: true },
@@ -109,217 +368,6 @@ impl From<&InstanceType> for Contract {
             InstanceType::Number => Contract::from(TypeF::Number),
             InstanceType::String => Contract::from(TypeF::String),
             InstanceType::Integer => Contract::from(static_access("std", ["number", "Integer"])),
-        }
-    }
-}
-
-impl TryFrom<&ObjectValidation> for Contract {
-    type Error = ();
-
-    fn try_from(value: &ObjectValidation) -> Result<Self, Self::Error> {
-        fn is_open_record(additional: Option<&Schema>) -> bool {
-            match additional {
-                Some(Schema::Bool(open)) => *open,
-                None => true,
-                _ => unreachable!("additional_properties must be checked beforehand"),
-            }
-        }
-
-        // box / deref patterns aren't stabilized, so we have to separate out
-        // `additional_properties` as a separate pattern
-        // SEE: https://github.com/rust-lang/rust/issues/29641
-        // SEE: https://github.com/rust-lang/rust/issues/87121
-        match (value, value.additional_properties.as_deref()) {
-            (
-                ObjectValidation {
-                    max_properties: None,
-                    min_properties: None,
-                    required,
-                    properties,
-                    pattern_properties,
-                    additional_properties,
-                    property_names: None,
-                },
-                None | Some(Schema::Bool(_)),
-            ) if pattern_properties.is_empty() => Ok(Contract::from(generate_record_contract(
-                required,
-                properties,
-                is_open_record(additional_properties.as_deref()),
-            ))),
-            _ => Err(()),
-        }
-    }
-}
-
-impl TryFrom<&ArrayValidation> for Contract {
-    type Error = ();
-
-    fn try_from(val: &ArrayValidation) -> Result<Self, Self::Error> {
-        if let ArrayValidation {
-            items: Some(SingleOrVec::Single(s)),
-            additional_items: None,
-            max_items: None,
-            min_items: None,
-            unique_items: None,
-            contains: None,
-        } = val
-        {
-            let elt = Contract::try_from(s.as_ref())
-                .unwrap_or_else(|_| contract_from_predicate(Predicate::from(s.as_ref())));
-            if let [elt] = elt.0.as_slice() {
-                Ok(Contract::from(TypeF::Array(Box::new(
-                    TypeF::Flat(elt.clone()).into(),
-                ))))
-            } else {
-                Err(())
-            }
-        } else {
-            Err(())
-        }
-    }
-}
-
-impl TryFrom<&SchemaObject> for Contract {
-    type Error = ();
-
-    fn try_from(value: &SchemaObject) -> Result<Self, Self::Error> {
-        match value {
-            // a raw type
-            SchemaObject {
-                metadata: _,
-                instance_type: Some(SingleOrVec::Single(instance_type)),
-                format: _,
-                enum_values: None,
-                const_value: None,
-                subschemas: None,
-                number: None,
-                string: None,
-                array: None,
-                object: None,
-                reference: None,
-                extensions,
-            } if only_ignored_fields(extensions) => {
-                // We ultimately produce a Flat type based on a contract with
-                // only a type in it. Semantically, this is kind of weird. But
-                // the pretty printer doesn't care, and it simplifies our code
-                // significantly.
-                Ok(Contract::from(instance_type.as_ref()))
-            }
-            // a reference to a definition
-            SchemaObject {
-                metadata: _,
-                instance_type: None,
-                format: None,
-                enum_values: None,
-                const_value: None,
-                subschemas: None,
-                number: None,
-                string: None,
-                array: None,
-                object: None,
-                reference: Some(reference),
-                extensions,
-            } if only_ignored_fields(extensions) => {
-                Ok(Contract::from(definitions::reference(reference).contract))
-            }
-            // a freeform record
-            SchemaObject {
-                metadata: _,
-                instance_type: Some(SingleOrVec::Single(instance_type)),
-                format: None,
-                enum_values: None,
-                const_value: None,
-                subschemas: None,
-                number: None,
-                string: None,
-                array: None,
-                object: None,
-                reference: None,
-                extensions,
-            } if **instance_type == InstanceType::Object && only_ignored_fields(extensions) => {
-                Ok(Contract::from(Term::Record(RecordData {
-                    attrs: RecordAttrs { open: true },
-                    ..Default::default()
-                })))
-            }
-            // a record with sub-field types specified
-            SchemaObject {
-                metadata: _,
-                instance_type: Some(SingleOrVec::Single(instance_type)),
-                format: None,
-                enum_values: None,
-                const_value: None,
-                subschemas: None,
-                number: None,
-                string: None,
-                array: None,
-                object: Some(ov),
-                reference: None,
-                extensions,
-            } if **instance_type == InstanceType::Object && only_ignored_fields(extensions) => {
-                ov.as_ref().try_into()
-            }
-            // Enum contract with all strings
-            // => | std.enum.TagOrString | [| 'foo, 'bar, 'baz |]
-            SchemaObject {
-                metadata: _,
-                instance_type: Some(SingleOrVec::Single(instance_type)),
-                format: None,
-                enum_values: Some(values),
-                const_value: None,
-                subschemas: None,
-                number: None,
-                string: None,
-                array: None,
-                object: None,
-                reference: None,
-                extensions: _,
-            } if **instance_type == InstanceType::String => {
-                let enum_rows: EnumRows =
-                    values
-                        .iter()
-                        .try_fold(EnumRows(EnumRowsF::Empty), |acc, value| {
-                            let id = match value {
-                                Value::String(s) => s.into(),
-                                _ => return Err(()),
-                            };
-                            Ok(EnumRows(EnumRowsF::Extend {
-                                row: id,
-                                tail: Box::new(acc),
-                            }))
-                        })?;
-                Ok(Contract(vec![
-                    static_access("std", ["enum", "TagOrString"]),
-                    Term::Type(TypeF::Enum(enum_rows).into()).into(),
-                ]))
-            }
-            SchemaObject {
-                metadata: _,
-                instance_type: Some(SingleOrVec::Single(instance_type)),
-                format: None,
-                enum_values: None,
-                const_value: None,
-                subschemas: None,
-                number: None,
-                string: None,
-                array: Some(av),
-                object: None,
-                reference: None,
-                extensions: _,
-            } if **instance_type == InstanceType::Array => av.as_ref().try_into(),
-            _ => Err(()),
-        }
-    }
-}
-
-impl TryFrom<&Schema> for Contract {
-    type Error = ();
-
-    fn try_from(value: &Schema) -> Result<Self, Self::Error> {
-        match value {
-            Schema::Bool(true) => Ok(Contract(vec![])),
-            Schema::Bool(false) => Err(()),
-            Schema::Object(obj) => obj.try_into(),
         }
     }
 }
@@ -377,12 +425,13 @@ fn generate_record_contract(
     required: &BTreeSet<String>,
     properties: &BTreeMap<String, Schema>,
     open: bool,
+    refs_usage: &mut RefsUsage,
 ) -> RichTerm {
     let fields = properties.iter().map(|(name, schema)| {
         // try to convert to a contract, otherwise convert the predicate version
         // to a contract
-        let contract = Contract::try_from(schema)
-            .unwrap_or_else(|()| contract_from_predicate(Predicate::from(schema)));
+        let contract = Contract::try_convert(schema, refs_usage)
+            .unwrap_or_else(|| Contract::convert_thru_pred(schema, refs_usage));
         let doc = Documentation::try_from(schema).ok();
         (
             name.into(),
@@ -405,12 +454,15 @@ fn generate_record_contract(
     .into()
 }
 
-/// Convert `predicate` into a contract, suitable for use in a contract
-/// assertion `term | Contract`.
-pub fn contract_from_predicate(predicate: Predicate) -> Contract {
-    mk_app!(
-        static_access("predicates", ["contract_from_predicate"]),
-        predicate
-    )
-    .into()
+impl From<Predicate> for Contract {
+    // Convert a predicate to a contract by calling a function similar to
+    // `std.contract.from_predicate` (but which does a bit more about propagating meaningful error
+    // messages)
+    fn from(pred: Predicate) -> Self {
+        mk_app!(
+            static_access("predicates", ["contract_from_predicate"]),
+            pred
+        )
+        .into()
+    }
 }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -107,7 +107,7 @@ impl JsonPointer {
         }
     }
 
-    /// Take a JSON pointer to a property and returns the corresponding path in the final
+    /// Take a JSON pointer to a property and return the corresponding path in the final
     /// generated contract, that is, with all the intermediate `properties` stripped.
     ///
     /// For example, running [Self::try_as_field_path] on a JSON pointer
@@ -117,7 +117,7 @@ impl JsonPointer {
         let mut result = Vec::with_capacity(self.path.len() / 2);
 
         // We expect that the path can be grouped as a sequence of two elements, where the first
-        // one is always `properties`, and the second one corresponds is the property name.
+        // one is always `properties`, and the second one corresponds to the property name.
         while let Some(part) = it.next() {
             if part != "properties" {
                 return None;
@@ -344,8 +344,8 @@ impl Environment {
     /// the conversion of this schema to a Nickel contract or predicate.
     ///
     /// Note that we have to repeat the creation process: when converting the referenced
-    /// definitions, those definitions might themselve reference other definitions that were not
-    /// used until now. We record those usage as well, and iterate until no new definition is ever
+    /// definitions, those definitions might themselves reference other definitions that were not
+    /// used until now. We record those usages as well, and iterate until no new definition is ever
     /// referenced.
     pub fn new(root_schema: &RootSchema, mut refs_usage: RefsUsage) -> Self {
         let mut definitions = HashMap::new();
@@ -416,8 +416,8 @@ impl Environment {
 
         // We need to pass a ref usage object when converting properties and definitions to put
         // them in the environment. However, we don't care about properties, because they've been
-        // converted at least once already (all properties inconditionally appear in the final
-        // contract). Thus, converting those properties again shoudln't add new usage, and we can
+        // converted at least once already (all properties unconditionally appear in the final
+        // contract). Thus, converting those properties again shouldn't add new usage, and we can
         // ignore their usage.
         let mut usage_placeholder = RefsUsage::new();
 
@@ -533,7 +533,7 @@ impl Environment {
 ///
 /// Note: it looks like we could return the original value upon empty path, but there's a mismatch:
 /// we get a `SchemaObject` reference, and we must return a `Schema` reference. We can't convert
-/// between the two (we can convert between the owned variants easily, but not for refernces).
+/// between the two (we can convert between the owned variants easily, but not for references).
 /// Since we can special case empty paths before calling to `get_property` if really needed, it's
 /// simpler to just return `None` here.
 pub fn get_property<'a>(schema_obj: &'a SchemaObject, path: &[String]) -> Option<&'a Schema> {

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -47,7 +47,7 @@ use crate::{
     contracts::{Contract, Documentation},
     predicates::Predicate,
     utils::{decode_json_ptr_part, static_access},
-    DEFINITIONS_MANGLED, ENVIRONMENT_MANGLED, PROPS_PREDICATES_MANGLED,
+    DEFINITIONS_ID, ENVIRONMENT_ID, PROPS_PREDICATES_ID,
 };
 
 /// Specify if a reference is used in a context which requires a contract or a predicate.
@@ -304,8 +304,8 @@ pub fn resolve_ref(reference: &str, state: &mut RefsUsage, usage: RefUsage) -> R
                     // as a separator as a key. See the documentation of `PROPS_PREDICATES_MANGLED`
                     // for more information.
                     static_access(
-                        ENVIRONMENT_MANGLED,
-                        [PROPS_PREDICATES_MANGLED, field_path.path.join("/").as_str()],
+                        ENVIRONMENT_ID,
+                        [PROPS_PREDICATES_ID, field_path.path.join("/").as_str()],
                     )
                 }
             }
@@ -313,16 +313,13 @@ pub fn resolve_ref(reference: &str, state: &mut RefsUsage, usage: RefUsage) -> R
             match usage {
                 RefUsage::Contract => {
                     state.defs_contracts.insert(name.clone());
-                    static_access(
-                        ENVIRONMENT_MANGLED,
-                        [DEFINITIONS_MANGLED, "contracts", name.as_ref()],
-                    )
+                    static_access(ENVIRONMENT_ID, [DEFINITIONS_ID, "contracts", name.as_ref()])
                 }
                 RefUsage::Predicate => {
                     state.defs_predicates.insert(name.clone());
                     static_access(
-                        ENVIRONMENT_MANGLED,
-                        [DEFINITIONS_MANGLED, "predicates", name.as_ref()],
+                        ENVIRONMENT_ID,
+                        [DEFINITIONS_ID, "predicates", name.as_ref()],
                     )
                 }
             }
@@ -499,15 +496,15 @@ impl Environment {
         // The enclosing record, with one field for the definitions and one for the properties
         let global_env = Term::Record(RecordData::with_field_values(
             [
-                (Ident::from(DEFINITIONS_MANGLED), defs),
-                (Ident::from(PROPS_PREDICATES_MANGLED), props),
+                (Ident::from(DEFINITIONS_ID), defs),
+                (Ident::from(PROPS_PREDICATES_ID), props),
             ]
             .into_iter()
             .collect(),
         ));
 
         Term::Let(
-            Ident::from(ENVIRONMENT_MANGLED),
+            Ident::from(ENVIRONMENT_ID),
             global_env.into(),
             inner,
             LetAttrs {

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -151,8 +151,10 @@ pub struct ConvertedSchema {
     contract: Contract,
 }
 
-/// The state used to record which properties and definitions are actually used, and how.
-pub struct RefsState {
+/// State recording which properties and definitions are actually used and how (as predicates or as
+/// contracts).
+#[derive(Clone, Default)]
+pub struct RefsUsage {
     /// The definitions referenced as predicates somewhere in the schema.
     pub defs_predicates: HashSet<String>,
     /// The definitions referenced as contracts somewhere in the schema.
@@ -162,6 +164,13 @@ pub struct RefsState {
     /// We don't need to keep track of the contracts, as they will inconditionnally be constituents
     /// of the final schema.
     pub props_predicates: HashSet<Vec<String>>,
+}
+
+impl RefsUsage {
+    /// The empty state
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 /// An environment of top level schema definitions and nested properties and their conversions into
@@ -198,7 +207,7 @@ pub struct Environment {
 ///   how. `resolve_ref` will update the state accordingly
 /// - `usage`: the context in which the reference is used. Some contexts requires a predicate,
 ///   while other can do with a contract.
-pub fn resolve_ref(reference: &str, state: &mut RefsState, usage: RefUsage) -> RichTerm {
+pub fn resolve_ref(reference: &str, state: &mut RefsUsage, usage: RefUsage) -> RichTerm {
     let unsupported_reference = || -> RichTerm {
         eprintln!(
             "
@@ -259,7 +268,7 @@ impl Environment {
 
     /// Create an environment from the top-level JSON schema and a ref state indicating which
     /// properties and definitions actually need to be considered.
-    pub fn new(root_schema: Schema, state: &RefsState) -> Self {
+    pub fn new(root_schema: Schema, state: &RefsUsage) -> Self {
         // FIXME: Definitions can have their own definitions. Does this handle that
         //        correctly? Does schema.rs even handle it correctly?
         todo!()

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -1,16 +1,36 @@
-//! # Reference handling for JSON schema
+//! Reference handling for JSON schema
 //!
-//! JSON schemas can contain a set of definitions at the top level and
-//! references to other schemas at essentially arbitrary points. The general
-//! format of JSON schema references is quite general. For example, it would be
-//! possible to reference fields in a schema hosted at a remote URI. We don't
-//! want to support the general case but we need a way of dealing with
-//! references to top-level definitions in a schema.
-//! This module handles an [`Environment`] data structure that keeps track of
-//! top-level definitions in a JSON schema and their translations into Nickel
-//! predicates and contracts.
+//! JSON schemas can reference other schemas at essentially arbitrary points through the special
+//! [`$ref`](https://json-schema.org/draft/2020-12/json-schema-core#name-direct-references-with-ref)
+//! attribute. Those references are very general: they are URI, which can point to a remote
+//! resource of the network. The fragment of the URI is a [JSON
+//! pointer](https://discord.com/channels/1174731094726295632/1179430745727586407/1225453786529660938),
+//! which is a path within the JSON schema to a specific attribute (note that it's not JSON-schema
+//! specific, but rather a general mechanism to index into a JSON value).
+//!
+//! We don't want to support the general case, at least for now, as it comes with its lot of
+//! complexity. However, we want to at least be capable of resolving all local references (i.e.
+//! reference to the current file).
+//!
+//! There are two different kinds of references:
+//!
+//! - references to top-level definitions in a schema. JSON schemas can contain a set of
+//! definitions at the top level and reference them from other parts of the schema.
+//! - references to other properties of the schema.
+//!
+//! In both cases, in order to resolve references, we might need either the contract or the
+//! predicate version of the converted schemas (both the predicate and the contract) for each
+//! definition and property, as we don't know yet if their usage will require the predicate form or
+//! the contract form. During conversion, we simply suppose that they are accessible through
+//! special values that are introduced at the top level by json-schema-to-nickel, e.g.
+//! `___nickel_defs` or `___nickel_props_preds`. Thus, we can refer to them with a statically known
+//! field path. We record along the way which properties or definitions are used, and if they are
+//! used as a contract or as a predicate.
+//!
+//! At the end, we can elaborate the required special values like `___nickel_defs` and only include
+//! the actually used in the final contract, to avoid bloating the result.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use nickel_lang_core::{
     identifier::Ident,
@@ -25,8 +45,103 @@ use schemars::schema::Schema;
 use crate::{
     contracts::{contract_from_predicate, Contract, Documentation},
     predicates::Predicate,
-    utils::static_access,
+    utils::{decode_json_ptr_part, static_access},
+    DEFINITIONS_MANGLED, PROPS_PREDICATES_MANGLED,
 };
+
+/// Specify if a reference is used in a context which requires a contract or a predicate.
+#[derive(Clone, Debug, Copy)]
+pub enum RefUsage {
+    Contract,
+    Predicate,
+}
+
+/// A representation of a field path in the final generated contract.
+///
+/// # Invariants
+///
+/// The path is guaranteed to be non-empty by construction. Do not directly mutate the underlying
+/// path with the risk of making it empty.
+#[derive(Hash, Clone, Debug, Default)]
+pub struct FieldPath {
+    path: Vec<String>,
+}
+
+pub struct EmptyFieldPath;
+
+impl TryFrom<Vec<String>> for FieldPath {
+    type Error = EmptyFieldPath;
+
+    fn try_from(path: Vec<String>) -> Result<Self, Self::Error> {
+        if path.is_empty() {
+            return Err(EmptyFieldPath);
+        }
+
+        Ok(Self { path })
+    }
+}
+
+impl From<FieldPath> for RichTerm {
+    fn from(field_path: FieldPath) -> Self {
+        // unwrap(): the `FieldPath` struct guarantees that the path is non-empty by construction.
+        static_access(
+            field_path.path.first().unwrap(),
+            field_path.path.iter().skip(1),
+        )
+    }
+}
+
+/// A representation of JSON pointer, which is mostly a path within a JSON document toward a
+/// specific value. See [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901).
+#[derive(Hash, Clone, Debug, Default)]
+pub struct JsonPointer {
+    pub path: Vec<String>,
+}
+
+impl JsonPointer {
+    fn new(ptr: &str) -> Self {
+        Self {
+            path: ptr.split('/').map(decode_json_ptr_part).collect(),
+        }
+    }
+
+    /// Take a path pointing to a property and returns the corresponding path in the final
+    /// generated contract, that is, with all the intermediate `properties` stripped.
+    ///
+    /// For example, running [Self::as_field_path] on a JSON pointer
+    /// `#/properties/foo/properties/bar` will return the field path `["foo", "bar"]`.
+    fn try_as_field_path(&self) -> Option<FieldPath> {
+        let mut it = self.path.iter();
+        let mut result = Vec::with_capacity(self.path.len() / 2);
+
+        // We expect that the path can be grouped as a sequence of two elements, where the first
+        // one is always `properties`, and the second one corresponds is the property name.
+        while let Some(part) = it.next() {
+            if part != "properties" {
+                return None;
+            }
+
+            if let Some(name) = it.next() {
+                result.push(name.clone());
+            } else {
+                return None;
+            }
+        }
+
+        FieldPath::try_from(result).ok()
+    }
+
+    /// Tries to interpret `self` as pointing to a top-level definition. A JSON pointer points to a
+    /// top-level definition if the path has exactly two elements and the first one is
+    /// `definitions`.
+    fn try_as_def(&self) -> Option<String> {
+        if self.path.len() == 2 && self.path[0] == "definitions" {
+            Some(self.path[1].clone())
+        } else {
+            None
+        }
+    }
+}
 
 /// The nickel predicate and contract generated for a schema.
 #[derive(Clone)]
@@ -36,41 +151,103 @@ pub struct ConvertedSchema {
     contract: Contract,
 }
 
-/// The field access for referencing the predicate or contract generated from a
-/// schema in other Nickel code.
-#[derive(Clone)]
-pub struct Access {
-    pub predicate: RichTerm,
-    pub contract: RichTerm,
+/// The state used to record which properties and definitions are actually used, and how.
+pub struct RefsState {
+    /// The definitions referenced as predicates somewhere in the schema.
+    pub defs_predicates: HashSet<String>,
+    /// The definitions referenced as contracts somewhere in the schema.
+    pub defs_contracts: HashSet<String>,
+    /// The properties referenced as predicates somewhere in the schema (stored as path).
+    ///
+    /// We don't need to keep track of the contracts, as they will inconditionnally be constituents
+    /// of the final schema.
+    pub props_predicates: HashSet<Vec<String>>,
 }
 
-/// An environment of top level schema definitions and their conversions into
+/// An environment of top level schema definitions and nested properties and their conversions into
 /// Nickel predicates and contracts.
 #[derive(Clone, Default)]
-pub struct Environment(HashMap<String, ConvertedSchema>);
-
-pub fn access(name: impl AsRef<str>) -> Access {
-    Access {
-        contract: static_access("definitions", ["contract", name.as_ref()]),
-        predicate: static_access("definitions", ["predicate", name.as_ref()]),
-    }
+pub struct Environment {
+    /// The top-level definition of the schema.
+    defs: HashMap<String, ConvertedSchema>,
+    /// The predicates of the properties of the schema. We only need to store the predicates, and
+    /// not the contract, as the contract are simply accessible recursively in the resulting
+    /// schema. For example, the contract for the reference `#/properties/foo/properties/bar` is
+    /// simply `foo.bar`.
+    ///
+    /// The key is the path the property. In our previous example, the key would be `["foo",
+    /// "bar"]`.
+    prop_predicates: HashMap<Vec<String>, ConvertedSchema>,
+    /// Although we store every property in the environment, we will only need to access the one
+    /// that are actually referenced in a `$ref` attribute, which is usually a small subset (and is
+    /// often entirely empty, if there's no local reference to a property).
+    ///
+    /// Thus, while elaborating the schema, we keep track of the properties that are actually used,
+    /// and only include those predicates in the final schema.
+    used_props: HashSet<Vec<String>>,
 }
 
-pub fn reference(reference: &str) -> Access {
-    if let Some(remainder) = reference.strip_prefix("#/definitions/") {
-        access(remainder)
-    } else {
+/// Resolve a JSON schema reference to a Nickel term. The resulting Nickel expression will have a
+/// different shape depending on the usage context and the type of reference (definition vs
+/// property).
+///
+/// # Arguments
+///
+/// - `reference`: the JSON schema reference to resolve. It must be a valid URI
+/// - `state`: the state used to record which properties and definitions are actually used, and
+///   how. `resolve_ref` will update the state accordingly
+/// - `usage`: the context in which the reference is used. Some contexts requires a predicate,
+///   while other can do with a contract.
+pub fn resolve_ref(reference: &str, state: &mut RefsState, usage: RefUsage) -> RichTerm {
+    let unsupported_reference = || -> RichTerm {
         eprintln!(
             "
-            Warning: skipping reference {reference} (replaced by an always succeeding `Dyn` \
-            contract). The current version of `json-schema-to-nickel` doesn't support external \
-            references"
+            Warning: skipping reference {reference} (replaced by an always succeeding \
+            `Dyn` contract). The current version of `json-schema-to-nickel` only supports \
+            internal references to top-level definitions or nested properties"
         );
 
-        Access {
-            contract: Term::Type(TypeF::Dyn.into()).into(),
-            predicate: static_access("predicates", ["always"]),
+        match usage {
+            RefUsage::Contract => Term::Type(TypeF::Dyn.into()).into(),
+            RefUsage::Predicate => static_access("predicates", ["always"]),
         }
+    };
+
+    if let Some(fragment) = reference.strip_prefix("#/") {
+        let json_ptr = JsonPointer::new(fragment);
+
+        if let Some(field_path) = json_ptr.try_as_field_path() {
+            match usage {
+                RefUsage::Contract => RichTerm::from(field_path),
+                RefUsage::Predicate => {
+                    // If we are referring to a property as a predicate, we need to keep track of it.
+                    state.props_predicates.insert(field_path.path.clone());
+                    // We don't index the properties elements by elements, as in
+                    // `<PROPS_PREDICATES_MANGLED>.foo.bar.baz`, but we use the whole path with `/`
+                    // as a separator as a key. See the documentation of `PROPS_PREDICATES_MANGLED`
+                    // for more information.
+                    static_access(
+                        PROPS_PREDICATES_MANGLED,
+                        [field_path.path.join("/").as_str()],
+                    )
+                }
+            }
+        } else if let Some(name) = json_ptr.try_as_def() {
+            match usage {
+                RefUsage::Contract => {
+                    state.defs_contracts.insert(name.clone());
+                    static_access(DEFINITIONS_MANGLED, [name.as_ref(), "contract"])
+                }
+                RefUsage::Predicate => {
+                    state.defs_predicates.insert(name.clone());
+                    static_access(DEFINITIONS_MANGLED, [name.as_ref(), "predicate"])
+                }
+            }
+        } else {
+            unsupported_reference()
+        }
+    } else {
+        unsupported_reference()
     }
 }
 
@@ -80,12 +257,20 @@ impl Environment {
         Self::default()
     }
 
+    /// Create an environment from the top-level JSON schema and a ref state indicating which
+    /// properties and definitions actually need to be considered.
+    pub fn new(root_schema: Schema, state: &RefsState) -> Self {
+        // FIXME: Definitions can have their own definitions. Does this handle that
+        //        correctly? Does schema.rs even handle it correctly?
+        todo!()
+    }
+
     /// Wrap a Nickel [`RichTerm`] in a let binding containing the definitions
     /// from the environment. This is necessary for the Nickel access terms
     /// tracked in the environment to actually work.
     pub fn wrap(self, inner: RichTerm) -> RichTerm {
         let contracts = self
-            .0
+            .defs
             .iter()
             .map(|(k, v)| {
                 (
@@ -101,8 +286,9 @@ impl Environment {
                 )
             })
             .collect();
+
         let predicates = self
-            .0
+            .defs
             .into_iter()
             .map(|(k, v)| {
                 (
@@ -118,6 +304,7 @@ impl Environment {
                 )
             })
             .collect();
+
         Term::Let(
             "definitions".into(),
             Term::Record(RecordData::with_field_values(
@@ -153,27 +340,25 @@ impl Environment {
     }
 }
 
-/// Convert the `definitions` field of a json schema mapping identifiers to
-/// Schemas to an [`Environment`] struct mapping identifiers to Nickel terms
-// FIXME: Definitions can have their own definitions. Does this handle that
-//        correctly? Does schema.rs even handle it correctly?
-impl From<&BTreeMap<String, Schema>> for Environment {
-    fn from(defs: &BTreeMap<String, Schema>) -> Self {
-        let terms = defs
-            .iter()
-            .map(|(name, schema)| {
-                (
-                    name.clone(),
-                    ConvertedSchema {
-                        doc: Documentation::try_from(schema).ok(),
-                        contract: Contract::try_from(schema).unwrap_or_else(|()| {
-                            contract_from_predicate(Predicate::from(access(name).predicate))
-                        }),
-                        predicate: Predicate::from(schema),
-                    },
-                )
-            })
-            .collect();
-        Environment(terms)
-    }
-}
+// /// Convert the `definitions` field of a json schema mapping identifiers to
+// /// Schemas to an [`Environment`] struct mapping identifiers to Nickel terms
+// impl From<&BTreeMap<String, Schema>> for Environment {
+//     fn from(defs: &BTreeMap<String, Schema>) -> Self {
+//         let terms = defs
+//             .iter()
+//             .map(|(name, schema)| {
+//                 (
+//                     name.clone(),
+//                     ConvertedSchema {
+//                         doc: Documentation::try_from(schema).ok(),
+//                         contract: Contract::try_from(schema).unwrap_or_else(|()| {
+//                             contract_from_predicate(Predicate::from(access_def(name).predicate))
+//                         }),
+//                         predicate: Predicate::from(schema),
+//                     },
+//                 )
+//             })
+//             .collect();
+//         Environment::new(terms)
+//     }
+// }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -30,7 +30,7 @@
 //! At the end, we can elaborate the required special values like `___nickel_defs` and only include
 //! the actually used in the final contract, to avoid bloating the result.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 use nickel_lang_core::{
     identifier::Ident,
@@ -43,7 +43,7 @@ use nickel_lang_core::{
 use schemars::schema::Schema;
 
 use crate::{
-    contracts::{contract_from_predicate, Contract, Documentation},
+    contracts::{Contract, Documentation},
     predicates::Predicate,
     utils::{decode_json_ptr_part, static_access},
     DEFINITIONS_MANGLED, PROPS_PREDICATES_MANGLED,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod definitions;
 pub mod predicates;
 pub(crate) mod utils;
 
-use contracts::{contract_from_predicate, Contract};
+use contracts::{AsCtrThruPred, Contract, TryAsContract};
 use definitions::Environment;
 use nickel_lang_core::{
     cache::{Cache, ErrorTolerance},
@@ -60,10 +60,11 @@ pub const PROPS_PREDICATES_MANGLED: &str = "___js2n_nickel_prop_preds";
 /// Otherwise, we fall back to generating a predicate.
 pub fn root_schema(root: &RootSchema) -> RichTerm {
     let env = Environment::new(todo!(), todo!());
-    if let Ok(contract) = Contract::try_from(&root.schema) {
+
+    if let Some((contract, _refs_usage)) = Contract::from_root_schema(root) {
         wrap_contract(env, contract)
     } else {
-        let predicate = Predicate::from(&root.schema);
+        let (predicate, _refs_usage) = Predicate::from(&root.schema);
         wrap_predicate(env, predicate)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ use schemars::schema::RootSchema;
 /// This Nickel variable is expected to have the type
 /// `{_ : {predicate: _, contract: _}}` where field names correspond to the top-level
 /// definitions in the schema.
-pub const DEFINITIONS_MANGLED : &str = "___js2n_nickel_defs";
+pub const DEFINITIONS_MANGLED: &str = "___js2n_nickel_defs";
 
 /// Same as [DEFINITIONS_MANGLED] but for the predicates corresponding to properties of the schema.
 ///
@@ -53,7 +53,7 @@ pub const DEFINITIONS_MANGLED : &str = "___js2n_nickel_defs";
 /// Properties can be nested, so we might need to store both a predicate for `foo` and for
 /// `foo.bar.baz`. To make this work, we store the predicates in a flat dictionary, where the keys
 /// are complete paths using `/` as a separator (to avoid confusion with Nickel field path).
-pub const PROPS_PREDICATES_MANGLED : &str = "___js2n_nickel_prop_preds";
+pub const PROPS_PREDICATES_MANGLED: &str = "___js2n_nickel_prop_preds";
 
 /// Convert a [`RootSchema`] into a Nickel contract. If the JSON schema is
 /// representable as a lazy record contract, this conversion is preferred.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ use schemars::schema::RootSchema;
 
 /// The top-level variable storing the json-schema-to-nickel predicate library included by default
 /// in any generated contract.
-pub const PREDICATES_LIBRARY: &str = "_js2n_nickel_preds_lib";
+pub const PREDICATES_LIBRARY: &str = "_js2n___nickel_preds_lib";
 
 /// The top-level variable storing the environment, that is the definitions and the properties
 /// referenced in the JSON schema (through the `$ref`) attribute. This variable stores
@@ -46,8 +46,7 @@ pub const PREDICATES_LIBRARY: &str = "_js2n_nickel_preds_lib";
 /// everywhere, including from other definitions and properties (in fact, we would like to have
 /// mutual recursive let definitions for [DEFINITIONS_MANGLED] and [PROPS_PREDICATES_MANGLED], but
 /// Nickel doesn't have mutually recursive lets, so we put both in a recursive record instead).
-// pub const ENVIRONMENT_MANGLED: &str = "___js2n_nickel_global_env";
-pub const ENVIRONMENT_MANGLED: &str = "_js2n_nickel_global_env";
+pub const ENVIRONMENT_MANGLED: &str = "_js2n___nickel_global_env";
 
 /// The name of the special variable introduced by json-schema-to-nickel in the final contract
 /// which holds the predicates and the contracts corresponding to the definitions of the schema.
@@ -57,8 +56,7 @@ pub const ENVIRONMENT_MANGLED: &str = "_js2n_nickel_global_env";
 /// This Nickel variable is expected to have the type
 /// `{_ : {predicate: _, contract: _}}` where field names correspond to the top-level
 /// definitions in the schema.
-// pub const DEFINITIONS_MANGLED: &str = "___js2n_nickel_defs";
-pub const DEFINITIONS_MANGLED: &str = "_js2n_nickel_defs";
+pub const DEFINITIONS_MANGLED: &str = "_js2n___nickel_defs";
 
 /// Same as [DEFINITIONS_MANGLED] but for the predicates corresponding to properties of the schema.
 ///
@@ -69,8 +67,7 @@ pub const DEFINITIONS_MANGLED: &str = "_js2n_nickel_defs";
 /// Properties can be nested, so we might need to store both a predicate for `foo` and for
 /// `foo.bar.baz`. To make this work, we store the predicates in a flat dictionary, where the keys
 /// are complete paths using `/` as a separator (to avoid confusion with Nickel field path).
-// pub const PROPS_PREDICATES_MANGLED: &str = "___js2n_nickel_prop_preds";
-pub const PROPS_PREDICATES_MANGLED: &str = "_js2n_nickel_prop_preds";
+pub const PROPS_PREDICATES_MANGLED: &str = "_js2n___nickel_prop_preds";
 
 /// Convert a [`RootSchema`] into a Nickel contract. If the JSON schema is
 /// representable as a lazy record contract, this conversion is preferred.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,17 +36,17 @@ use schemars::schema::RootSchema;
 
 /// The top-level variable storing the json-schema-to-nickel predicate library included by default
 /// in any generated contract.
-pub const PREDICATES_LIBRARY: &str = "_js2n___nickel_preds_lib";
+pub const PREDICATES_LIBRARY_ID: &str = "_js2n___nickel_preds_lib";
 
 /// The top-level variable storing the environment, that is the definitions and the properties
 /// referenced in the JSON schema (through the `$ref`) attribute. This variable stores
-/// [DEFINITIONS_MANGLED] and [PROPS_PREDICATES_MANGLED], each in their own field.
+/// [DEFINITIONS_ID] and [PROPS_PREDICATES_ID], each in their own field.
 ///
 /// We put both under the same variable so that definitions and properties are accessible from
 /// everywhere, including from other definitions and properties (in fact, we would like to have
-/// mutual recursive let definitions for [DEFINITIONS_MANGLED] and [PROPS_PREDICATES_MANGLED], but
+/// mutual recursive let definitions for [DEFINITIONS_ID] and [PROPS_PREDICATES_ID], but
 /// Nickel doesn't have mutually recursive lets, so we put both in a recursive record instead).
-pub const ENVIRONMENT_MANGLED: &str = "_js2n___nickel_global_env";
+pub const ENVIRONMENT_ID: &str = "_js2n___nickel_global_env";
 
 /// The name of the special variable introduced by json-schema-to-nickel in the final contract
 /// which holds the predicates and the contracts corresponding to the definitions of the schema.
@@ -56,18 +56,18 @@ pub const ENVIRONMENT_MANGLED: &str = "_js2n___nickel_global_env";
 /// This Nickel variable is expected to have the type
 /// `{_ : {predicate: _, contract: _}}` where field names correspond to the top-level
 /// definitions in the schema.
-pub const DEFINITIONS_MANGLED: &str = "_js2n___nickel_defs";
+pub const DEFINITIONS_ID: &str = "_js2n___nickel_defs";
 
-/// Same as [DEFINITIONS_MANGLED] but for the predicates corresponding to properties of the schema.
+/// Same as [DEFINITIONS_ID] but for the predicates corresponding to properties of the schema.
 ///
 /// This Nickel variable is expected to have the type `{_ : Dyn -> Bool}` where predicates are
-/// directly stored without further indirection, as opposed to [DEFINITIONS_MANGLED]. Indeed, we
-/// don't need the contract part, which can be accessed directly from within the final schema.
+/// directly stored without further indirection, as opposed to [DEFINITIONS_ID]. Indeed, we don't
+/// need the contract part, which can be accessed directly from within the final schema.
 ///
 /// Properties can be nested, so we might need to store both a predicate for `foo` and for
 /// `foo.bar.baz`. To make this work, we store the predicates in a flat dictionary, where the keys
 /// are complete paths using `/` as a separator (to avoid confusion with Nickel field path).
-pub const PROPS_PREDICATES_MANGLED: &str = "_js2n___nickel_prop_preds";
+pub const PROPS_PREDICATES_ID: &str = "_js2n___nickel_prop_preds";
 
 /// Convert a [`RootSchema`] into a Nickel contract. If the JSON schema is
 /// representable as a lazy record contract, this conversion is preferred.
@@ -95,7 +95,7 @@ pub fn wrap_contract(env: Environment, contract: Contract) -> RichTerm {
     let lib_rt = parser.parse_strict(file_id, lexer).unwrap();
 
     Term::Let(
-        PREDICATES_LIBRARY.into(),
+        PREDICATES_LIBRARY_ID.into(),
         lib_rt,
         env.wrap(contract.into()),
         Default::default(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,3 +11,10 @@ where
 {
     make::static_access(make::var(record), fields)
 }
+
+/// Replace special escaping sequences by the actual character within one element of a JSON pointer
+/// path. See the [JSON pointer syntax](https://datatracker.ietf.org/doc/html/rfc6901#section-3).
+/// Currently, this just amounts to replace `~0` by `~` and `~1` by `/`.
+pub fn decode_json_ptr_part(part: &str) -> String {
+    part.replace("~0", "~").replace("~1", "/")
+}

--- a/tests/json_schema_test_suite_test.rs
+++ b/tests/json_schema_test_suite_test.rs
@@ -1,11 +1,11 @@
+use schemars::schema::Schema;
 use std::io::stderr;
 
 use json_schema_test_suite::{json_schema_test_suite, TestCase};
 use json_schema_to_nickel::{
-    definitions::Environment, predicates::Predicate, root_schema, wrap_predicate,
+    definitions::Environment, predicates::AsPredicate, root_schema, wrap_contract,
 };
 use nickel_lang_core::{eval::cache::lazy::CBNCache, program::Program, term::RichTerm};
-use schemars::schema::Schema;
 use stringreader::StringReader;
 
 #[json_schema_test_suite("vendor/JSON-Schema-Test-Suite", "draft7", {
@@ -34,11 +34,15 @@ fn translation_typecheck_test(
     let contract = if test_case.schema.is_object() {
         root_schema(&dbg!(serde_json::from_value(test_case.schema).unwrap()))
     } else {
-        wrap_predicate(
+        // Otherwise, we have to work a bit to convet a `Schema` instead of `RootSchema`, because
+        // the json-schema-to-nickel API tries hard to ensure we always convert a whole root schema
+        // for reference handling reasons.
+
+        let schema: Schema = dbg!(serde_json::from_value(test_case.schema).unwrap());
+
+        wrap_contract(
             Environment::empty(),
-            Predicate::from(dbg!(
-                &serde_json::from_value::<Schema>(test_case.schema).unwrap()
-            )),
+            schema.as_predicate(&mut Default::default()).into(),
         )
     };
 

--- a/tests/json_schema_test_suite_test.rs
+++ b/tests/json_schema_test_suite_test.rs
@@ -34,10 +34,6 @@ fn translation_typecheck_test(
     let contract = if test_case.schema.is_object() {
         root_schema(&dbg!(serde_json::from_value(test_case.schema).unwrap()))
     } else {
-        // Otherwise, we have to work a bit to convet a `Schema` instead of `RootSchema`, because
-        // the json-schema-to-nickel API tries hard to ensure we always convert a whole root schema
-        // for reference handling reasons.
-
         let schema: Schema = dbg!(serde_json::from_value(test_case.schema).unwrap());
 
         wrap_contract(


### PR DESCRIPTION
This pull request implements support local references to not only top-level definitions, but also properties, that is a JSON pointer of the form `#/properties/foo/properties/bar/.../properties/qux`.

## Motivation

Currently, json-schema-to-nickel is only able to handle local references to top-level definitions, that is references of the form "#/definitions/xxx`. Beside simply supporting more schemas, the motivation here is that [json-schema-ref-parser](https://github.com/APIDevTools/json-schema-ref-parser) can help users circumvent the fact that json-schema-to-nickel currently doesn't support external refs by bundling the external refs directly into the schemas. However, this tool most often produces references of the second form, that is `#/properties/foo/properties/bar`, so it can't be used yet as a pre-processing step to make json-schema-to-nickel able to handle external references.

## Design

Definitions aren't that special, so we extend the idea of definitions which is to introduce special variables (the "environment") handling the conversion of properties as contracts and predicates to be used from anywhere within the schema.

However, there are a few differences.

### Code bloat

Definitions are usually, by nature, supposed to be used in the schema. Many schema don't have definitions at all, and those who do most of the time actually use them. Also, definitions should make for a small part of the final schema.

This is different for properties, which are the substance of most JSON schemas. If we blindly make them all available as contracts and predicates in the environment, we will thus potentially duplicate each property 3 times, whether it's actually useful or not: once as a contract in the final schema, and twice in the environment, as a predicate and a contract. It also means we have to hold those two versions (contracts & predicates) somewhere in memory throughout the conversion.

We assume that the happy path is that schemas don't have any local references (or few), and want to optimize for that case. Thus, it would be better to only introduce in the environment the properties _that are actually referenced somewhere_.

### Contracts are already there

Definitions aren't part of the final schema per se, but are only in the environment. However, properties are always part of the final schema, at least their contract version. Thus, we don't need to duplicate the contract version in the environment: we can just use a simple and direct recursive access.

In consequence, we only include the predicate version of reference properties in the environment, to reduce further the code bloat of the generated contract.

## Solution

The main idea is to pass additional state around during the conversion of the root schema. This state (`RefsUsage`) maintains 3 sets:

1. The top-level definitions used as a predicate
2. The top-level definitions used as a contract
3. The properties used as a predicate

We can't rely on the `From`/`TryFrom` trait and introduce similar bespoke traits for the conversion from schemas to `Predicate` or `Contract`.

Then, at the end of the conversion, we build the environment from the usage registered during the conversion. Building correctly the definition part is iterative: indeed, when constructing the definitions, we convert new schemas that were unseen until now (the definitions), which can themselves reference new definitions. We thus iterate until we don't see any new definitions anymore.

Property predicates are stored in the environment as a flat record: a path `#/properties/foo/properties/bar` will be included as an entry `"foo/bar" = value` in `<env>.<prop_preds>`.

The final environment is put in special variable, with mangled names (to avoid unwanted clashes with properties of the schema).

## Follow-up

- This PR only supports paths of the form `properties/x/properties/y`, but it shouldn't be too hard to support more general JSON pointers, for example I've seen `#/allOf/0` be generated by `json-schema-ref-parser` as well. This is left for future work given the size of the current PR
- While all the tests pass, the new feature isn't tested per se (schema with local references to properties). For the same reason (PR size), this is left for a follow-up PR.