### PR TITLE
Support percent-encoded URIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +701,7 @@ name = "json-schema-to-nickel"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "fluent-uri",
  "json_schema_test_suite",
  "lazy_static",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 clap = { version = "^4.3", features = ["derive"] }
+fluent-uri = "0.1.4"
 nickel-lang-core = { git = "https://github.com/tweag/nickel", rev = "refs/heads/master", default-features = false }
 
 pretty = "^0.11"

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -24,7 +24,7 @@
 //! ```
 //!
 //! is turned into the Nickel type `Bool`.
-use crate::definitions::RefUsageContext;
+use crate::references::RefUsageContext;
 use nickel_lang_core::typ::EnumRowF;
 use schemars::schema::RootSchema;
 use std::collections::{BTreeMap, BTreeSet};
@@ -45,8 +45,8 @@ use schemars::schema::{
 use serde_json::Value;
 
 use crate::{
-    definitions::{self, RefsUsage},
     predicates::{AsPredicate, Predicate},
+    references::{self, RefsUsage},
     utils::static_access,
     PREDICATES_LIBRARY_ID,
 };
@@ -161,7 +161,7 @@ impl TryAsContract for SchemaObject {
                 object: None,
                 reference: Some(reference),
                 extensions,
-            } if only_ignored_fields(extensions) => Some(Contract::from(definitions::resolve_ref(
+            } if only_ignored_fields(extensions) => Some(Contract::from(references::resolve_ref(
                 reference,
                 refs_usage,
                 RefUsageContext::Contract,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,18 +20,18 @@
 //! generates a predicate. In either case, the result is wrapped with the
 //! necessary bindings to the predicate support library and returned.
 pub mod contracts;
-pub mod definitions;
 pub mod predicates;
+pub mod references;
 pub(crate) mod utils;
 
 use contracts::Contract;
-use definitions::Environment;
 use nickel_lang_core::{
     cache::{Cache, ErrorTolerance, SourcePath},
     parser::{grammar::TermParser, lexer::Lexer, ErrorTolerantParser},
     term::{RichTerm, Term},
 };
 use predicates::Predicate;
+use references::Environment;
 use schemars::schema::RootSchema;
 
 /// The top-level variable storing the json-schema-to-nickel predicate library included by default

--- a/src/predicates.rs
+++ b/src/predicates.rs
@@ -20,7 +20,7 @@ use schemars::schema::{
 use serde_json::Value;
 
 use crate::{
-    definitions::{self, RefUsageContext, RefsUsage},
+    references::{self, RefUsageContext, RefsUsage},
     utils::static_access,
     PREDICATES_LIBRARY_ID,
 };
@@ -638,7 +638,7 @@ impl AsPredicate for SchemaObject {
         );
 
         args.extend(reference.as_deref().map(|r| {
-            Predicate::from(definitions::resolve_ref(
+            Predicate::from(references::resolve_ref(
                 r,
                 refs_usage,
                 RefUsageContext::Predicate,

--- a/tests/json_schema_test_suite_test.rs
+++ b/tests/json_schema_test_suite_test.rs
@@ -3,7 +3,7 @@ use std::io::stderr;
 
 use json_schema_test_suite::{json_schema_test_suite, TestCase};
 use json_schema_to_nickel::{
-    definitions::Environment, predicates::AsPredicate, root_schema, wrap_contract,
+    predicates::AsPredicate, references::Environment, root_schema, wrap_contract,
 };
 use nickel_lang_core::{
     error::{Error, EvalError},
@@ -32,11 +32,8 @@ use stringreader::StringReader;
     // The following are references that aren't yet handled by js2n (remote URIs, local files
     // and non-top level definitions)
     "ref_0_3.*", // reference to the whole schema `#` not yet supported
-    "ref_3_2.*", // we don't properly percent-decode URIs
     "ref_12_1.*", // reference to bare URI `node` (no fragment, no leading slash). Should fail
                   // because invalid, but js2n replace that by a `Dyn` contract
-    "ref_13_0.*", // we don't properly percent-decode URIs
-    "ref_13_1.*", // we don't properly percent-decode URIs
     "ref_14_1.*", // reference to an anchor "#foo" not yet supported
     "ref_15_1.*", // anchor + remote URI
     "ref_16_1.*", // external reference (remote URI)
@@ -59,7 +56,6 @@ use stringreader::StringReader;
     "ref_31_1.*", // external reference (absolute path /absref/foobar.json)
     "ref_34_0.*", // non top-level definition ("#/definitions//definitions/")
     "ref_34_1.*", // non top-level definition ("#/definitions//definitions/")
-    "ref_3_5.*", // schemars doesn't properly percent-decode URIs
     "ref_5_1.*", // not related to external ref, but js2n doesn't properly ignore other components
                  // when the `ref` field is used
     "ref_6_0.*", // reference to a local file (foo.json)


### PR DESCRIPTION
Depends on #77.

This PR makes use of a proper URI parser, in particular to correctly support JSON schema references with percent-encoded characters. This might also prove useful if we ever want to resolve distant URIs at some point. Note that the `url` crate doesn't support the same RFC as JSON schemas, which accepts any URI fragment. I tried to find a crate with a mix of reasonable number of downloads, maturity, and reasonably recent activity for URI parsing.

Unrelatedly, the `definitions` module is renamed to `references` to better reflect the fact that it now manages general reference resolution, and not just definitions. A bunch of warning messages are marginally improved as well.