### PR TITLE
Support for nested definitions

### DIFF
--- a/tests/json_schema_test_suite_test.rs
+++ b/tests/json_schema_test_suite_test.rs
@@ -54,8 +54,6 @@ use stringreader::StringReader;
     "ref_29_0.*", // external reference (remote URI)
     "ref_30_0.*", // external reference (remote URI)
     "ref_31_1.*", // external reference (absolute path /absref/foobar.json)
-    "ref_34_0.*", // non top-level definition ("#/definitions//definitions/")
-    "ref_34_1.*", // non top-level definition ("#/definitions//definitions/")
     "ref_5_1.*", // not related to external ref, but js2n doesn't properly ignore other components
                  // when the `ref` field is used
     "ref_6_0.*", // reference to a local file (foo.json)


### PR DESCRIPTION
schemars doesn't properly handle definitions that aren't at the top-level (there's no proper field), however, unsupported data like those are still stored as pure JSON values inside the `extensions` field.

This PR uses this field to properly handle nested definitions, by manually deserializing the JSON value obtained  on-the-fly to a JSON schema. This requires sprinkling some `Cow` instead of pure references to make rustc happy while still borrowing data as much as possible (avoiding useless clones).

Interestingly, this approach can be extended for other JSON schema keywords that aren't currently supported by schemars.