### PR TITLE
More contracts

### DIFF
--- a/examples/github-workflow/ci.ncl
+++ b/examples/github-workflow/ci.ncl
@@ -44,5 +44,5 @@
   |> std.serialize 'Json
   |> std.deserialize 'Json
 )
-  | (import "github-workflow.schema.ncl")
+  | (import "../../out.ncl")
 

--- a/examples/github-workflow/ci.ncl
+++ b/examples/github-workflow/ci.ncl
@@ -15,7 +15,7 @@
         branches = ["main"]
       },
       pull_request = {
-        branches = ["main"]
+        branch = ["main"]
       }
     },
 

--- a/examples/github-workflow/github-workflow.json
+++ b/examples/github-workflow/github-workflow.json
@@ -1,6 +1,7 @@
 {
-  "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/github-workflow.json",
+  "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions",
   "additionalProperties": false,
   "definitions": {
     "architecture": {
@@ -162,6 +163,9 @@
         "actions": {
           "$ref": "#/definitions/permissions-level"
         },
+        "attestations": {
+          "$ref": "#/definitions/permissions-level"
+        },
         "checks": {
           "$ref": "#/definitions/permissions-level"
         },
@@ -266,7 +270,7 @@
         "issue_comment",
         "issues",
         "label",
-        "member",
+        "merge_group",
         "milestone",
         "page_build",
         "project",
@@ -300,13 +304,13 @@
       "additionalProperties": true
     },
     "expressionSyntax": {
-      "type": "string",
       "$comment": "escape `{` and `}` in pattern to be unicode compatible (#1360)",
+      "type": "string",
       "pattern": "^\\$\\{\\{(.|[\r\n])*\\}\\}$"
     },
     "stringContainingExpressionSyntax": {
-      "type": "string",
       "$comment": "escape `{` and `}` in pattern to be unicode compatible (#1360)",
+      "type": "string",
       "pattern": "^.*\\$\\{\\{(.|[\r\n])*\\}\\}.*$"
     },
     "globs": {
@@ -385,11 +389,105 @@
           "type": "string"
         },
         {
-          "type": "string",
           "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#custom-shell",
+          "type": "string",
           "enum": ["bash", "pwsh", "python", "sh", "cmd", "powershell"]
         }
       ]
+    },
+    "step": {
+      "type": "object",
+      "additionalProperties": false,
+      "dependencies": {
+        "working-directory": ["run"],
+        "shell": ["run"]
+      },
+      "oneOf": [
+        {
+          "required": ["uses"]
+        },
+        {
+          "required": ["run"]
+        }
+      ],
+      "properties": {
+        "id": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsid",
+          "description": "A unique identifier for the step. You can use the id to reference the step in contexts. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
+          "type": "string"
+        },
+        "if": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsif",
+          "description": "You can use the if conditional to prevent a step from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
+          "type": ["boolean", "number", "string"]
+        },
+        "name": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsname",
+          "description": "A name for your step to display on GitHub.",
+          "type": "string"
+        },
+        "uses": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsuses",
+          "description": "Selects an action to run as part of a step in your job. An action is a reusable unit of code. You can use an action defined in the same repository as the workflow, a public repository, or in a published Docker container image (https://hub.docker.com/).\nWe strongly recommend that you include the version of the action you are using by specifying a Git ref, SHA, or Docker tag number. If you don't specify a version, it could break your workflows or cause unexpected behavior when the action owner publishes an update.\n- Using the commit SHA of a released action version is the safest for stability and security.\n- Using the specific major action version allows you to receive critical fixes and security patches while still maintaining compatibility. It also assures that your workflow should still work.\n- Using the master branch of an action may be convenient, but if someone releases a new major version with a breaking change, your workflow could break.\nSome actions require inputs that you must set using the with keyword. Review the action's README file to determine the inputs required.\nActions are either JavaScript files or Docker containers. If the action you're using is a Docker container you must run the job in a Linux virtual environment. For more details, see https://help.github.com/en/articles/virtual-environments-for-github-actions.",
+          "type": "string"
+        },
+        "run": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun",
+          "description": "Runs command-line programs using the operating system's shell. If you do not provide a name, the step name will default to the text specified in the run command.\nCommands run using non-login shells by default. You can choose a different shell and customize the shell used to run commands. For more information, see https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell.\nEach run keyword represents a new process and shell in the virtual environment. When you provide multi-line commands, each line runs in the same shell.",
+          "type": "string"
+        },
+        "working-directory": {
+          "$ref": "#/definitions/working-directory"
+        },
+        "shell": {
+          "$ref": "#/definitions/shell"
+        },
+        "with": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswith",
+          "$ref": "#/definitions/env",
+          "description": "A map of the input parameters defined by the action. Each input parameter is a key/value pair. Input parameters are set as environment variables. The variable is prefixed with INPUT_ and converted to upper case.",
+          "properties": {
+            "args": {
+              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswithargs",
+              "type": "string"
+            },
+            "entrypoint": {
+              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswithentrypoint",
+              "type": "string"
+            }
+          }
+        },
+        "env": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsenv",
+          "$ref": "#/definitions/env",
+          "description": "Sets environment variables for steps to use in the virtual environment. You can also set environment variables for the entire workflow or a job."
+        },
+        "continue-on-error": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error",
+          "description": "Prevents a job from failing when a step fails. Set to true to allow a job to pass when this step fails.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/expressionSyntax"
+            }
+          ],
+          "default": false
+        },
+        "timeout-minutes": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes",
+          "description": "The maximum number of minutes to run the step before killing the process.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/expressionSyntax"
+            }
+          ]
+        }
+      }
     },
     "types": {
       "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onevent_nametypes",
@@ -418,6 +516,53 @@
         }
       ]
     },
+    "matrix": {
+      "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix",
+      "description": "A build matrix is a set of different configurations of the virtual environment. For example you might run a job against more than one supported version of a language, operating system, or tool. Each configuration is a copy of the job that runs and reports a status.\nYou can specify a matrix by supplying an array for the configuration options. For example, if the GitHub virtual environment supports Node.js versions 6, 8, and 10 you could specify an array of those versions in the matrix.\nWhen you define a matrix of operating systems, you must set the required runs-on keyword to the operating system of the current job, rather than hard-coding the operating system name. To access the operating system name, you can use the matrix.os context parameter to set runs-on. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
+      "oneOf": [
+        {
+          "type": "object",
+          "patternProperties": {
+            "^(in|ex)clude$": {
+              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#example-including-configurations-in-a-matrix-build",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/expressionSyntax"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "$ref": "#/definitions/configuration"
+                    }
+                  },
+                  "minItems": 1
+                }
+              ]
+            }
+          },
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/configuration"
+                },
+                "minItems": 1
+              },
+              {
+                "$ref": "#/definitions/expressionSyntax"
+              }
+            ]
+          },
+          "minProperties": 1
+        },
+        {
+          "$ref": "#/definitions/expressionSyntax"
+        }
+      ]
+    },
     "reusableWorkflowCallJob": {
       "$comment": "https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#calling-a-reusable-workflow",
       "description": "Each job must have an id to associate with the job. The key job_id is a string and its value is a map of the job's configuration data. You must replace <job_id> with a string that is unique to the jobs object. The <job_id> must start with a letter or _ and contain only alphanumeric characters, -, or _.",
@@ -432,7 +577,7 @@
           "$ref": "#/definitions/jobNeeds"
         },
         "permissions": {
-          "$ref": "#/definitions/permissions-event"
+          "$ref": "#/definitions/permissions"
         },
         "if": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idif",
@@ -443,12 +588,12 @@
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iduses",
           "description": "The location and version of a reusable workflow file to run as a job, of the form './{path/to}/{localfile}.yml' or '{owner}/{repo}/{path}/{filename}@{ref}'. {ref} can be a SHA, a release tag, or a branch name. Using the commit SHA is the safest for stability and security.",
           "type": "string",
-          "pattern": "^(.+/)+(.+)\\.(ya?ml)(@.+)?$"
+          "pattern": "^(.+\\/)+(.+)\\.(ya?ml)(@.+)?$"
         },
         "with": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idwith",
-          "description": "A map of inputs that are passed to the called workflow. Any inputs that you pass must match the input specifications defined in the called workflow. Unlike 'jobs.<job_id>.steps[*].with', the inputs you pass with 'jobs.<job_id>.with' are not be available as environment variables in the called workflow. Instead, you can reference the inputs by using the inputs context.",
-          "$ref": "#/definitions/env"
+          "$ref": "#/definitions/env",
+          "description": "A map of inputs that are passed to the called workflow. Any inputs that you pass must match the input specifications defined in the called workflow. Unlike 'jobs.<job_id>.steps[*].with', the inputs you pass with 'jobs.<job_id>.with' are not be available as environment variables in the called workflow. Instead, you can reference the inputs by using the inputs context."
         },
         "secrets": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idsecrets",
@@ -469,49 +614,12 @@
           "type": "object",
           "properties": {
             "matrix": {
-              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix",
-              "description": "A build matrix is a set of different configurations of the virtual environment. For example you might run a job against more than one supported version of a language, operating system, or tool. Each configuration is a copy of the job that runs and reports a status.\nYou can specify a matrix by supplying an array for the configuration options. For example, if the GitHub virtual environment supports Node.js versions 6, 8, and 10 you could specify an array of those versions in the matrix.\nWhen you define a matrix of operating systems, you must set the required runs-on keyword to the operating system of the current job, rather than hard-coding the operating system name. To access the operating system name, you can use the matrix.os context parameter to set runs-on. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-              "oneOf": [
-                {
-                  "type": "object"
-                },
-                {
-                  "$ref": "#/definitions/expressionSyntax"
-                }
-              ],
-              "patternProperties": {
-                "^(in|ex)clude$": {
-                  "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#example-including-configurations-in-a-matrix-build",
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "$ref": "#/definitions/configuration"
-                    }
-                  },
-                  "minItems": 1
-                }
-              },
-              "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/configuration"
-                    },
-                    "minItems": 1
-                  },
-                  {
-                    "$ref": "#/definitions/expressionSyntax"
-                  }
-                ]
-              },
-              "minProperties": 1
+              "$ref": "#/definitions/matrix"
             },
             "fail-fast": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast",
               "description": "When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true",
-              "type": "boolean",
+              "type": ["boolean", "string"],
               "default": true
             },
             "max-parallel": {
@@ -558,32 +666,10 @@
         "runs-on": {
           "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idruns-on",
           "description": "The type of machine to run the job on. The machine can be either a GitHub-hosted runner, or a self-hosted runner.",
-          "oneOf": [
+          "anyOf": [
             {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#github-hosted-runners",
-              "type": "string",
-              "enum": [
-                "macos-10.15",
-                "macos-11",
-                "macos-12",
-                "macos-12-xl",
-                "macos-13",
-                "macos-13-xl",
-                "macos-latest",
-                "macos-latest-xl",
-                "self-hosted",
-                "ubuntu-18.04",
-                "ubuntu-20.04",
-                "ubuntu-22.04",
-                "ubuntu-latest",
-                "ubuntu-latest-4-cores",
-                "ubuntu-latest-8-cores",
-                "ubuntu-latest-16-cores",
-                "windows-2019",
-                "windows-2022",
-                "windows-latest",
-                "windows-latest-8-cores"
-              ]
+              "type": "string"
             },
             {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#self-hosted-runners",
@@ -592,99 +678,10 @@
                 {
                   "items": [
                     {
-                      "const": "self-hosted"
+                      "type": "string"
                     }
                   ],
-                  "minItems": 1,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "self-hosted"
-                    },
-                    {
-                      "$ref": "#/definitions/machine"
-                    }
-                  ],
-                  "minItems": 2,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "self-hosted"
-                    },
-                    {
-                      "$ref": "#/definitions/architecture"
-                    }
-                  ],
-                  "minItems": 2,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "self-hosted"
-                    },
-                    {
-                      "$ref": "#/definitions/machine"
-                    },
-                    {
-                      "$ref": "#/definitions/architecture"
-                    }
-                  ],
-                  "minItems": 3,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "self-hosted"
-                    },
-                    {
-                      "$ref": "#/definitions/architecture"
-                    },
-                    {
-                      "$ref": "#/definitions/machine"
-                    }
-                  ],
-                  "minItems": 3,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "linux"
-                    }
-                  ],
-                  "minItems": 2,
-                  "maxItems": 2,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "windows"
-                    }
-                  ],
-                  "minItems": 2,
-                  "maxItems": 2,
-                  "additionalItems": {
-                    "type": "string"
-                  }
+                  "minItems": 1
                 }
               ]
             },
@@ -712,6 +709,9 @@
             },
             {
               "$ref": "#/definitions/stringContainingExpressionSyntax"
+            },
+            {
+              "$ref": "#/definitions/expressionSyntax"
             }
           ]
         },
@@ -728,7 +728,7 @@
           ]
         },
         "outputs": {
-          "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjobs_idoutputs",
+          "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idoutputs",
           "description": "A map of outputs for a job. Job outputs are available to all downstream jobs that depend on this job.",
           "type": "object",
           "additionalProperties": {
@@ -756,116 +756,7 @@
           "description": "A job contains a sequence of tasks called steps. Steps can run commands, run setup tasks, or run an action in your repository, a public repository, or an action published in a Docker registry. Not all steps run actions, but all actions run as a step. Each step runs in its own process in the virtual environment and has access to the workspace and filesystem. Because steps run in their own process, changes to environment variables are not preserved between steps. GitHub provides built-in steps to set up and complete a job.\nMust contain either `uses` or `run`\n",
           "type": "array",
           "items": {
-            "allOf": [
-              {
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "uses": {
-                        "type": "string"
-                      }
-                    },
-                    "required": ["uses"]
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "run": {
-                        "type": "string"
-                      }
-                    },
-                    "required": ["run"]
-                  }
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsid",
-                    "description": "A unique identifier for the step. You can use the id to reference the step in contexts. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-                    "type": "string"
-                  },
-                  "if": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsif",
-                    "description": "You can use the if conditional to prevent a step from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-                    "type": ["boolean", "number", "string"]
-                  },
-                  "name": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsname",
-                    "description": "A name for your step to display on GitHub.",
-                    "type": "string"
-                  },
-                  "uses": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsuses",
-                    "description": "Selects an action to run as part of a step in your job. An action is a reusable unit of code. You can use an action defined in the same repository as the workflow, a public repository, or in a published Docker container image (https://hub.docker.com/).\nWe strongly recommend that you include the version of the action you are using by specifying a Git ref, SHA, or Docker tag number. If you don't specify a version, it could break your workflows or cause unexpected behavior when the action owner publishes an update.\n- Using the commit SHA of a released action version is the safest for stability and security.\n- Using the specific major action version allows you to receive critical fixes and security patches while still maintaining compatibility. It also assures that your workflow should still work.\n- Using the master branch of an action may be convenient, but if someone releases a new major version with a breaking change, your workflow could break.\nSome actions require inputs that you must set using the with keyword. Review the action's README file to determine the inputs required.\nActions are either JavaScript files or Docker containers. If the action you're using is a Docker container you must run the job in a Linux virtual environment. For more details, see https://help.github.com/en/articles/virtual-environments-for-github-actions.",
-                    "type": "string"
-                  },
-                  "run": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun",
-                    "description": "Runs command-line programs using the operating system's shell. If you do not provide a name, the step name will default to the text specified in the run command.\nCommands run using non-login shells by default. You can choose a different shell and customize the shell used to run commands. For more information, see https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell.\nEach run keyword represents a new process and shell in the virtual environment. When you provide multi-line commands, each line runs in the same shell.",
-                    "type": "string"
-                  },
-                  "working-directory": {
-                    "$ref": "#/definitions/working-directory"
-                  },
-                  "shell": {
-                    "$ref": "#/definitions/shell"
-                  },
-                  "with": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswith",
-                    "$ref": "#/definitions/env",
-                    "description": "A map of the input parameters defined by the action. Each input parameter is a key/value pair. Input parameters are set as environment variables. The variable is prefixed with INPUT_ and converted to upper case.",
-                    "properties": {
-                      "args": {
-                        "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswithargs",
-                        "type": "string"
-                      },
-                      "entrypoint": {
-                        "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswithentrypoint",
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "env": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsenv",
-                    "$ref": "#/definitions/env",
-                    "description": "Sets environment variables for steps to use in the virtual environment. You can also set environment variables for the entire workflow or a job."
-                  },
-                  "continue-on-error": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error",
-                    "description": "Prevents a job from failing when a step fails. Set to true to allow a job to pass when this step fails.",
-                    "oneOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "$ref": "#/definitions/expressionSyntax"
-                      }
-                    ],
-                    "default": false
-                  },
-                  "timeout-minutes": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes",
-                    "description": "The maximum number of minutes to run the step before killing the process.",
-                    "oneOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/definitions/expressionSyntax"
-                      }
-                    ]
-                  }
-                },
-                "dependencies": {
-                  "working-directory": ["run"],
-                  "shell": ["run"]
-                },
-                "additionalProperties": false
-              }
-            ]
+            "$ref": "#/definitions/step"
           },
           "minItems": 1
         },
@@ -888,49 +779,12 @@
           "type": "object",
           "properties": {
             "matrix": {
-              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix",
-              "description": "A build matrix is a set of different configurations of the virtual environment. For example you might run a job against more than one supported version of a language, operating system, or tool. Each configuration is a copy of the job that runs and reports a status.\nYou can specify a matrix by supplying an array for the configuration options. For example, if the GitHub virtual environment supports Node.js versions 6, 8, and 10 you could specify an array of those versions in the matrix.\nWhen you define a matrix of operating systems, you must set the required runs-on keyword to the operating system of the current job, rather than hard-coding the operating system name. To access the operating system name, you can use the matrix.os context parameter to set runs-on. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-              "oneOf": [
-                {
-                  "type": "object"
-                },
-                {
-                  "$ref": "#/definitions/expressionSyntax"
-                }
-              ],
-              "patternProperties": {
-                "^(in|ex)clude$": {
-                  "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#example-including-configurations-in-a-matrix-build",
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "$ref": "#/definitions/configuration"
-                    }
-                  },
-                  "minItems": 1
-                }
-              },
-              "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/configuration"
-                    },
-                    "minItems": 1
-                  },
-                  {
-                    "$ref": "#/definitions/expressionSyntax"
-                  }
-                ]
-              },
-              "minProperties": 1
+              "$ref": "#/definitions/matrix"
             },
             "fail-fast": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast",
               "description": "When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true",
-              "type": "boolean",
+              "type": ["boolean", "string"],
               "default": true
             },
             "max-parallel": {
@@ -988,6 +842,131 @@
         }
       },
       "required": ["runs-on"],
+      "additionalProperties": false
+    },
+    "workflowDispatchInput": {
+      "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_id",
+      "description": "A string identifier to associate with the input. The value of <input_id> is a map of the input's metadata. The <input_id> must be a unique identifier within the inputs object. The <input_id> must start with a letter or _ and contain only alphanumeric characters, -, or _.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddescription",
+          "description": "A string description of the input parameter.",
+          "type": "string"
+        },
+        "deprecationMessage": {
+          "description": "A string shown to users using the deprecated input.",
+          "type": "string"
+        },
+        "required": {
+          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_idrequired",
+          "description": "A boolean to indicate whether the action requires the input parameter. Set to true when the parameter is required.",
+          "type": "boolean"
+        },
+        "default": {
+          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddefault",
+          "description": "A string representing the default value. The default value is used when an input parameter isn't specified in a workflow file."
+        },
+        "type": {
+          "$comment": "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputsinput_idtype",
+          "description": "A string representing the type of the input.",
+          "type": "string",
+          "enum": ["string", "choice", "boolean", "number", "environment"]
+        },
+        "options": {
+          "$comment": "https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows",
+          "description": "The options of the dropdown list, if the type is a choice.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "string"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "default": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "boolean"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "default": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "number"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "default": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "environment"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "default": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "choice"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["options"]
+          }
+        }
+      ],
+      "required": ["description"],
       "additionalProperties": false
     }
   },
@@ -1236,21 +1215,6 @@
                 }
               }
             },
-            "member": {
-              "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows#member-event-member",
-              "$ref": "#/definitions/eventObject",
-              "description": "Runs your workflow anytime the member event occurs. More than one activity type triggers this event. For information about the REST API, see https://developer.github.com/v3/repos/collaborators/.",
-              "properties": {
-                "types": {
-                  "$ref": "#/definitions/types",
-                  "items": {
-                    "type": "string",
-                    "enum": ["added", "edited", "deleted"]
-                  },
-                  "default": ["added", "edited", "deleted"]
-                }
-              }
-            },
             "merge_group": {
               "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows#merge_group",
               "$ref": "#/definitions/eventObject",
@@ -1391,10 +1355,14 @@
                       "ready_for_review",
                       "locked",
                       "unlocked",
+                      "milestoned",
+                      "demilestoned",
                       "review_requested",
                       "review_request_removed",
                       "auto_merge_enabled",
-                      "auto_merge_disabled"
+                      "auto_merge_disabled",
+                      "enqueued",
+                      "dequeued"
                     ]
                   },
                   "default": ["opened", "synchronize", "reopened"]
@@ -1547,7 +1515,6 @@
             "workflow_call": {
               "$comment": "https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_call",
               "description": "Allows workflows to be reused by other workflows.",
-              "type": ["object", "null"],
               "properties": {
                 "inputs": {
                   "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onworkflow_callinputs",
@@ -1594,12 +1561,10 @@
                 "secrets": {
                   "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callsecrets",
                   "description": "A map of the secrets that can be used in the called workflow. Within the called workflow, you can use the secrets context to refer to a secret.",
-                  "type": "object",
                   "patternProperties": {
                     "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
                       "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callsecretssecret_id",
                       "description": "A string identifier to associate with the secret.",
-                      "type": "object",
                       "properties": {
                         "description": {
                           "description": "A string description of the secret parameter.",
@@ -1622,7 +1587,6 @@
             "workflow_dispatch": {
               "$comment": "https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/",
               "description": "You can now create workflows that are manually triggered with the new workflow_dispatch event. You will then see a 'Run workflow' button on the Actions tab, enabling you to easily trigger a run.",
-              "type": ["object", "null"],
               "properties": {
                 "inputs": {
                   "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputs",
@@ -1630,152 +1594,24 @@
                   "type": "object",
                   "patternProperties": {
                     "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
-                      "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_id",
-                      "description": "A string identifier to associate with the input. The value of <input_id> is a map of the input's metadata. The <input_id> must be a unique identifier within the inputs object. The <input_id> must start with a letter or _ and contain only alphanumeric characters, -, or _.",
-                      "type": "object",
-                      "properties": {
-                        "description": {
-                          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddescription",
-                          "description": "A string description of the input parameter.",
-                          "type": "string"
-                        },
-                        "deprecationMessage": {
-                          "description": "A string shown to users using the deprecated input.",
-                          "type": "string"
-                        },
-                        "required": {
-                          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_idrequired",
-                          "description": "A boolean to indicate whether the action requires the input parameter. Set to true when the parameter is required.",
-                          "type": "boolean"
-                        },
-                        "default": {
-                          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddefault",
-                          "description": "A string representing the default value. The default value is used when an input parameter isn't specified in a workflow file."
-                        },
-                        "type": {
-                          "description": "A string representing the type of the input.",
-                          "$comment": "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputsinput_idtype",
-                          "type": "string",
-                          "enum": [
-                            "string",
-                            "choice",
-                            "boolean",
-                            "number",
-                            "environment"
-                          ]
-                        },
-                        "options": {
-                          "$comment": "https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows",
-                          "description": "The options of the dropdown list, if the type is a choice.",
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "minItems": 1
-                        }
-                      },
-                      "allOf": [
-                        {
-                          "if": {
-                            "properties": {
-                              "type": {
-                                "const": "string"
-                              }
-                            },
-                            "required": ["type"]
-                          },
-                          "then": {
-                            "properties": {
-                              "default": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "if": {
-                            "properties": {
-                              "type": {
-                                "const": "boolean"
-                              }
-                            },
-                            "required": ["type"]
-                          },
-                          "then": {
-                            "properties": {
-                              "default": {
-                                "type": "boolean"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "if": {
-                            "properties": {
-                              "type": {
-                                "const": "number"
-                              }
-                            },
-                            "required": ["type"]
-                          },
-                          "then": {
-                            "properties": {
-                              "default": {
-                                "type": "number"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "if": {
-                            "properties": {
-                              "type": {
-                                "const": "environment"
-                              }
-                            },
-                            "required": ["type"]
-                          },
-                          "then": {
-                            "properties": {
-                              "default": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "if": {
-                            "properties": {
-                              "type": {
-                                "const": "choice"
-                              }
-                            },
-                            "required": ["type"]
-                          },
-                          "then": {
-                            "required": ["options"]
-                          }
-                        }
-                      ],
-                      "required": ["description"],
-                      "additionalProperties": false
+                      "$ref": "#/definitions/workflowDispatchInput"
                     }
                   },
                   "additionalProperties": false
                 }
-              }
+              },
+              "additionalProperties": false
             },
             "workflow_run": {
               "$comment": "https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run",
               "$ref": "#/definitions/eventObject",
               "description": "This event occurs when a workflow run is requested or completed, and allows you to execute a workflow based on the finished result of another workflow. For example, if your pull_request workflow generates build artifacts, you can create a new workflow that uses workflow_run to analyze the results and add a comment to the original pull request.",
-              "type": ["object", "null"],
               "properties": {
                 "types": {
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["requested", "completed"]
+                    "enum": ["requested", "completed", "in_progress"]
                   },
                   "default": ["requested", "completed"]
                 },

--- a/examples/github-workflow/github-workflow.json
+++ b/examples/github-workflow/github-workflow.json
@@ -1799,9 +1799,7 @@
                 "type": "object",
                 "properties": {
                   "cron": {
-                    "$comment": "https://stackoverflow.com/a/57639657/4044345",
-                    "type": "string",
-                    "pattern": "^(((\\d+,)+\\d+|((\\d+|\\*)/\\d+|((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?))|(\\d+-\\d+)|\\d+(-\\d+)?/\\d+(-\\d+)?|\\d+|\\*|(MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?) ?){5}$"
+                    "type": "string"
                   }
                 },
                 "additionalProperties": false

--- a/examples/github-workflow/github-workflow.json
+++ b/examples/github-workflow/github-workflow.json
@@ -1796,6 +1796,7 @@
               "description": "You can schedule a workflow to run at specific UTC times using POSIX cron syntax (https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07). Scheduled workflows run on the latest commit on the default or base branch. The shortest interval you can run scheduled workflows is once every 5 minutes.\nNote: GitHub Actions does not support the non-standard syntax @yearly, @monthly, @weekly, @daily, @hourly, and @reboot.\nYou can use crontab guru (https://crontab.guru/). to help generate your cron syntax and confirm what time it will run. To help you get started, there is also a list of crontab guru examples (https://crontab.guru/examples.html).",
               "type": "array",
               "items": {
+                "type": "object",
                 "properties": {
                   "cron": {
                     "$comment": "https://stackoverflow.com/a/57639657/4044345",

--- a/examples/github-workflow/github-workflow.json
+++ b/examples/github-workflow/github-workflow.json
@@ -1547,6 +1547,7 @@
             "workflow_call": {
               "$comment": "https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_call",
               "description": "Allows workflows to be reused by other workflows.",
+              "type": ["object", "null"],
               "properties": {
                 "inputs": {
                   "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onworkflow_callinputs",
@@ -1593,10 +1594,12 @@
                 "secrets": {
                   "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callsecrets",
                   "description": "A map of the secrets that can be used in the called workflow. Within the called workflow, you can use the secrets context to refer to a secret.",
+                  "type": "object",
                   "patternProperties": {
                     "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
                       "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callsecretssecret_id",
                       "description": "A string identifier to associate with the secret.",
+                      "type": "object",
                       "properties": {
                         "description": {
                           "description": "A string description of the secret parameter.",
@@ -1619,6 +1622,7 @@
             "workflow_dispatch": {
               "$comment": "https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/",
               "description": "You can now create workflows that are manually triggered with the new workflow_dispatch event. You will then see a 'Run workflow' button on the Actions tab, enabling you to easily trigger a run.",
+              "type": ["object", "null"],
               "properties": {
                 "inputs": {
                   "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputs",
@@ -1765,6 +1769,7 @@
               "$comment": "https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run",
               "$ref": "#/definitions/eventObject",
               "description": "This event occurs when a workflow run is requested or completed, and allows you to execute a workflow based on the finished result of another workflow. For example, if your pull_request workflow generates build artifacts, you can create a new workflow that uses workflow_run to analyze the results and add a comment to the original pull request.",
+              "type": ["object", "null"],
               "properties": {
                 "types": {
                   "$ref": "#/definitions/types",

--- a/lib/arrays.ncl
+++ b/lib/arrays.ncl
@@ -208,11 +208,17 @@ let error_lib = import "./error.ncl" in
   contract = {
     minItems
       : Number -> Dyn
+      | doc m%"
+        A contract that checks whether an array has at least a certain number of items.
+      "%
       = fun n =>
         std.contract.from_predicate (fun arr => std.typeof arr == 'Array && std.array.length (arr | Array Dyn) >= n),
 
     maxItems
       : Number -> Dyn
+      | doc m%"
+        A contract that checks whether an array has at most a certain number of items.
+      "%
       = fun n =>
         std.contract.from_predicate (fun arr => std.typeof arr == 'Array && std.array.length (arr | Array Dyn) <= n),
   }

--- a/lib/arrays.ncl
+++ b/lib/arrays.ncl
@@ -203,5 +203,17 @@ let error_lib = import "./error.ncl" in
           if has_duplicate then
             error_lib.mk_error "duplicate found: %{std.serialize 'Json duplicate}"
           else
-            'Ok
+            'Ok,
+
+  contract = {
+    minItems
+      : Number -> Dyn
+      = fun n =>
+        std.contract.from_predicate (fun arr => std.typeof arr == 'Array && std.array.length (arr | Array Dyn) >= n),
+
+    maxItems
+      : Number -> Dyn
+      = fun n =>
+        std.contract.from_predicate (fun arr => std.typeof arr == 'Array && std.array.length (arr | Array Dyn) <= n),
+  }
 }

--- a/lib/arrays.ncl
+++ b/lib/arrays.ncl
@@ -207,19 +207,19 @@ let error_lib = import "./error.ncl" in
 
   contract = {
     minItems
-      : Number -> Dyn
+      | Number -> Dyn
       | doc m%"
         A contract that checks whether an array has at least a certain number of items.
       "%
       = fun n =>
-        std.contract.from_predicate (fun arr => std.typeof arr == 'Array && std.array.length (arr | Array Dyn) >= n),
+        std.contract.from_predicate (fun arr => std.typeof arr == 'Array && std.array.length arr >= n),
 
     maxItems
-      : Number -> Dyn
+      | Number -> Dyn
       | doc m%"
         A contract that checks whether an array has at most a certain number of items.
       "%
       = fun n =>
-        std.contract.from_predicate (fun arr => std.typeof arr == 'Array && std.array.length (arr | Array Dyn) <= n),
+        std.contract.from_predicate (fun arr => std.typeof arr == 'Array && std.array.length arr <= n),
   }
 }

--- a/lib/predicates.ncl
+++ b/lib/predicates.ncl
@@ -269,14 +269,24 @@ let error_lib = import "./error.ncl" in
       ),
 
   contract = {
-    or_null : Dyn -> Dyn = fun Contract =>
-      std.contract.custom (fun label value =>
-        if value == null then
-          'Ok value
-        else
-          std.contract.check Contract label value
-      ),
+    or_null
+      : Dyn -> Dyn
+      | doc m%"
+        For a contract `C`, `or_null C` returns a contract that allows either `C` or a null value.
+      "%
+      = fun Contract =>
+        std.contract.custom (fun label value =>
+          if value == null then
+            'Ok value
+          else
+            std.contract.check Contract label value
+        ),
 
-    always : Dyn = std.contract.custom (fun label value => 'Ok value),
+    always
+      : Dyn
+      | doc m%"
+        A contract that always succeeds. The same as `Dyn`, but maybe with a clearer name.
+      "%
+      = std.contract.custom (fun label value => 'Ok value),
   }
 }

--- a/lib/predicates.ncl
+++ b/lib/predicates.ncl
@@ -267,4 +267,12 @@ let error_lib = import "./error.ncl" in
         predicate value
         |> error_lib.to_validator_result
       ),
+
+    or_null : Dyn -> Dyn = fun Contract => std.contract.custom (fun label value =>
+      if value == null then
+      'Ok value
+      else std.contract.check Contract label value
+    ),
+
+    always_ctr : Dyn = std.contract.custom (fun label value => 'Ok value)
 }

--- a/lib/predicates.ncl
+++ b/lib/predicates.ncl
@@ -283,7 +283,6 @@ let error_lib = import "./error.ncl" in
         ),
 
     always
-      : Dyn
       | doc m%"
         A contract that always succeeds. The same as `Dyn`, but with a more JSON-schema name.
       "%

--- a/lib/predicates.ncl
+++ b/lib/predicates.ncl
@@ -268,11 +268,15 @@ let error_lib = import "./error.ncl" in
         |> error_lib.to_validator_result
       ),
 
-    or_null : Dyn -> Dyn = fun Contract => std.contract.custom (fun label value =>
-      if value == null then
-      'Ok value
-      else std.contract.check Contract label value
-    ),
+  contract = {
+    or_null : Dyn -> Dyn = fun Contract =>
+      std.contract.custom (fun label value =>
+        if value == null then
+          'Ok value
+        else
+          std.contract.check Contract label value
+      ),
 
-    always_ctr : Dyn = std.contract.custom (fun label value => 'Ok value),
+    always : Dyn = std.contract.custom (fun label value => 'Ok value),
+  }
 }

--- a/lib/predicates.ncl
+++ b/lib/predicates.ncl
@@ -274,5 +274,5 @@ let error_lib = import "./error.ncl" in
       else std.contract.check Contract label value
     ),
 
-    always_ctr : Dyn = std.contract.custom (fun label value => 'Ok value)
+    always_ctr : Dyn = std.contract.custom (fun label value => 'Ok value),
 }

--- a/lib/predicates.ncl
+++ b/lib/predicates.ncl
@@ -285,7 +285,7 @@ let error_lib = import "./error.ncl" in
     always
       : Dyn
       | doc m%"
-        A contract that always succeeds. The same as `Dyn`, but maybe with a clearer name.
+        A contract that always succeeds. The same as `Dyn`, but with a more JSON-schema name.
       "%
       = std.contract.custom (fun label value => 'Ok value),
   }

--- a/lib/records.ncl
+++ b/lib/records.ncl
@@ -296,4 +296,50 @@ let error_lib = import "./error.ncl" in
                 }
             )
             'Ok,
+
+  contract = {
+    maxProperties
+      | Number -> Dyn
+      = fun n =>
+        std.contract.from_validator (fun x =>
+          if !std.is_record x then
+            'Error { message = "expected a record" }
+          else if std.record.length x > n then
+            'Error { message = "record contains more than %{std.string.from_number n} fields" }
+          else
+            'Ok
+        ),
+
+    minProperties
+      | Number -> Dyn
+      = fun n =>
+        std.contract.from_validator (fun x =>
+          if !std.is_record x then
+            'Error { message = "expected a record" }
+          else if std.record.length x < n then
+            'Error { message = "record contains less than %{std.string.from_number n} fields" }
+          else
+            'Ok
+        ),
+
+    patternFields | String -> Dyn = fun regex =>
+      let is_match = std.string.is_match regex in
+      std.contract.from_validator (fun x =>
+        if !std.is_record x then
+          'Error { message = "expected a record" }
+        else
+          let bad_field_names =
+            std.record.fields x
+            |> std.array.filter (fun k => !(is_match k))
+            |> std.array.map (fun k => m%""${k}""%)
+          in
+          if std.array.length bad_field_names > 0 then
+            'Error {
+              message = "invalid field names %{std.string.join "," bad_field_names}",
+              notes = ["expected fields to match %{regex}"]
+            }
+          else
+            'Ok
+      ),
+  }
 }

--- a/lib/records.ncl
+++ b/lib/records.ncl
@@ -338,7 +338,7 @@ let error_lib = import "./error.ncl" in
           let bad_field_names =
             std.record.fields x
             |> std.array.filter (fun k => !(is_match k))
-            |> std.array.map (fun k => m%""${k}""%)
+            |> std.array.map (fun k => "`${k}`")
           in
           if std.array.length bad_field_names > 0 then
             'Error {

--- a/lib/records.ncl
+++ b/lib/records.ncl
@@ -300,6 +300,9 @@ let error_lib = import "./error.ncl" in
   contract = {
     maxProperties
       | Number -> Dyn
+      | doc m%"
+        A contract asserting that the value is a record with at most a specific number of properties.
+      "%
       = fun n =>
         std.contract.from_validator (fun x =>
           if !std.is_record x then
@@ -312,6 +315,9 @@ let error_lib = import "./error.ncl" in
 
     minProperties
       | Number -> Dyn
+      | doc m%"
+        A contract asserting that the value is a record with at least a specific number of properties.
+      "%
       = fun n =>
         std.contract.from_validator (fun x =>
           if !std.is_record x then
@@ -322,6 +328,7 @@ let error_lib = import "./error.ncl" in
             'Ok
         ),
 
+    # TODO: replace with FieldsMatch once that's in a nickel release
     patternFields | String -> Dyn = fun regex =>
       let is_match = std.string.is_match regex in
       std.contract.from_validator (fun x =>

--- a/lib/strings.ncl
+++ b/lib/strings.ncl
@@ -55,4 +55,39 @@
           message = "expected a string matching the pattern `%{pattern}`",
           source = [],
         },
+
+  contract = {
+    Pattern | String -> Dyn = fun regex =>
+      std.contract.from_validator (fun s =>
+        let is_match = std.string.is_match regex in
+        if !std.is_string s then
+          'Error { message = "expected a string" }
+        else if !is_match s then
+          'Error { message = "expected %{regex}" }
+        else
+          'Ok
+      ),
+
+    MinLength | Number -> Dyn = (fun len =>
+      std.contract.from_validator (fun s =>
+        if !std.is_string s then
+          'Error { message = "expected a string" }
+        else if std.string.length s < len then
+          'Error { message = "expected at least %{len} characters" }
+        else
+          'Ok
+      )
+    ),
+
+    MaxLength | Number -> Dyn = (fun len =>
+      std.contract.from_validator (fun s =>
+        if !std.is_string s then
+          'Error { message = "expected a string" }
+        else if std.string.length s > len then
+          'Error { message = "expected at most %{len} characters" }
+        else
+          'Ok
+      )
+    ),
+  },
 }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -24,10 +24,13 @@
 //! ```
 //!
 //! is turned into the Nickel type `Bool`.
-use crate::references::RefUsageContext;
+use crate::{
+    references::RefUsageContext,
+    utils::{distinct, schema_types},
+};
 use nickel_lang_core::typ::EnumRowF;
 use schemars::schema::{RootSchema, SubschemaValidation};
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 use nickel_lang_core::{
     label::Label,
@@ -455,45 +458,6 @@ impl TryAsContract for ArrayValidation {
     }
 }
 
-fn distinct<T: std::hash::Hash + Eq>(items: impl Iterator<Item = T>) -> bool {
-    let mut seen = HashSet::new();
-    for item in items {
-        if !seen.insert(item) {
-            return false;
-        }
-    }
-    true
-}
-
-fn schema_simple_type(s: &Schema, root_schema: &RootSchema) -> Option<InstanceType> {
-    match s {
-        Schema::Bool(_) => None,
-        Schema::Object(SchemaObject {
-            instance_type: Some(instance_type),
-            ..
-        }) => MaybeNull::from_types(instance_type).inner().copied(),
-        Schema::Object(SchemaObject {
-            metadata: _,
-            instance_type: None,
-            format: None,
-            enum_values: None,
-            const_value: None,
-            subschemas: None,
-            number: None,
-            string: None,
-            array: None,
-            object: None,
-            reference: Some(reference),
-            extensions: _,
-        }) => {
-            let ptr = references::resolve_ptr(reference)?;
-            let s = ptr.resolve(root_schema)?;
-            schema_simple_type(&s, root_schema)
-        }
-        _ => None,
-    }
-}
-
 impl TryAsContract for SubschemaValidation {
     fn try_as_contract(
         &self,
@@ -517,6 +481,10 @@ impl TryAsContract for SubschemaValidation {
                 })
                 .collect::<Option<Vec<_>>>()
                 .map(Contract::from_terms),
+
+            // If the various options in an any_of combinator all have eagerly-distinguishable
+            // types then we can safely turn it into a lazy contract. The same goes for one_of,
+            // because the types are all different and so one_of is effectively any_of.
             SubschemaValidation {
                 all_of: None,
                 any_of: Some(any_of),
@@ -537,7 +505,10 @@ impl TryAsContract for SubschemaValidation {
             } => {
                 let types = any_of
                     .iter()
-                    .map(|s| schema_simple_type(s, root_schema))
+                    .map(|s| {
+                        schema_types(s, root_schema)
+                            .and_then(|tys| MaybeNull::from_types(&tys).inner().copied())
+                    })
                     .collect::<Vec<_>>();
                 if types.iter().all(|opt| opt.is_some()) && distinct(types.into_iter()) {
                     // FIXME: handle the case that any of them is nullable

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -395,16 +395,13 @@ impl TryAsContract for SchemaObject {
                 },
                 Some(InstanceType::String),
             ) if only_ignored_fields(extensions) => string.try_as_contract(root_schema, refs_usage),
-            _ => {
-                dbg!(self);
-                eprintln!("NO MATCH");
-                None
-            }
+            _ => None,
         };
 
-        match instance_type {
-            Some(SimpleType::Nullable(_)) => Some(ctr?.or_null()),
-            _ => ctr,
+        if let Some(SimpleType::Nullable(_)) = instance_type {
+            Some(ctr?.or_null())
+        } else {
+            ctr
         }
     }
 }
@@ -446,7 +443,8 @@ impl TryAsContract for ObjectValidation {
                 root_schema,
                 refs_usage,
             ))),
-            // Dicts that have a regex pattern on their fields.
+            // Dicts that have a single regex pattern on their fields and no additional fields
+            // get `{ _: schema}` and  `FieldsMatch regex` contracts.
             (
                 ObjectValidation {
                     max_properties,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod contracts;
 pub mod predicates;
 pub mod references;
+pub mod transform;
 pub(crate) mod utils;
 
 use contracts::Contract;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let schema: RootSchema = serde_json::from_reader(f)?;
-    let schema = transform::merge_defs(schema);
+    let schema = transform::inline_defs(schema);
     let schema = transform::lift_any_of_types(schema);
 
     let size = terminal_size()

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use clap::Parser;
-use json_schema_to_nickel::convert;
+use json_schema_to_nickel::{convert, transform};
 use nickel_lang_core::pretty::*;
 use schemars::schema::RootSchema;
 use terminal_size::{terminal_size, Width};
@@ -39,6 +39,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let schema: RootSchema = serde_json::from_reader(f)?;
+    let schema = transform::merge_defs(schema);
+    let schema = transform::lift_any_of_types(schema);
 
     let size = terminal_size()
         .map(|(Width(w), _)| w as usize)

--- a/src/references.rs
+++ b/src/references.rs
@@ -637,7 +637,9 @@ impl RefsUsage {
     }
 }
 
-pub fn resolve_ptr(reference: &str) -> Option<SchemaPointer> {
+/// Parses a JSON schema reference to a `SchemaPointer`, returning `None` and printing
+/// a warning if it's a kind of reference that we don't support.
+pub fn parse_ref(reference: &str) -> Option<SchemaPointer> {
     let Ok(uri) = fluent_uri::Uri::parse(reference) else {
         eprintln!(
             "Warning: skipping reference `{reference}` (replaced by an always succeeding \
@@ -719,7 +721,7 @@ pub fn resolve_ref(
         refs_usage: &mut RefsUsage,
         usage: RefUsageContext,
     ) -> Option<RichTerm> {
-        let schema_ptr = resolve_ptr(reference)?;
+        let schema_ptr = parse_ref(reference)?;
         refs_usage.record_usage(schema_ptr.clone(), usage);
         Some(schema_ptr.access(usage))
     }

--- a/src/references.rs
+++ b/src/references.rs
@@ -637,6 +637,66 @@ impl RefsUsage {
     }
 }
 
+pub fn resolve_ptr(reference: &str) -> Option<SchemaPointer> {
+    let Ok(uri) = fluent_uri::Uri::parse(reference) else {
+        eprintln!(
+            "Warning: skipping reference `{reference}` (replaced by an always succeeding \
+                contract). Failed to parse it as valid URI."
+        );
+
+        return None;
+    };
+
+    // If the URI has anything else than a fragment, we bail out.
+    if uri.scheme().is_some()
+        || uri.authority().is_some()
+        || !uri.path().as_str().is_empty()
+        || uri.query().is_some()
+    {
+        eprintln!(
+            "Warning: skipping external reference `{reference}` (replaced by an always \
+                succeeding contract). The current version of json-schema-to-nickel only supports \
+                internal references"
+        );
+
+        return None;
+    }
+
+    // We don't support (yet) relative fragments.
+    let Some(fragment) = uri
+        .fragment()
+        .map(|fragment| fragment.decode().into_string_lossy())
+    else {
+        eprintln!(
+            "Warning: skipping reference `{reference}` (replaced by an always succeeding \
+                contract). The URI doesn't have a fragment"
+        );
+
+        return None;
+    };
+
+    let Some(stripped) = fragment.strip_prefix('/') else {
+        eprintln!(
+            "Warning: skipping reference `{reference}` (replaced by an always succeeding \
+                contract). json-schema-to-nickel doesn't handle references to element ids."
+        );
+
+        return None;
+    };
+
+    match SchemaPointer::parse(stripped) {
+        Ok(ptr) => Some(ptr),
+        Err(err) => {
+            eprintln!(
+                "Warning: skipping reference `{reference}` (replaced by an always \
+                    succeeding contract). {err}"
+            );
+
+            None
+        }
+    }
+}
+
 /// Resolve a JSON schema reference to a Nickel term. The resulting Nickel expression will have a
 /// different shape depending on the usage context and the type of reference (definition vs
 /// property).
@@ -659,64 +719,7 @@ pub fn resolve_ref(
         refs_usage: &mut RefsUsage,
         usage: RefUsageContext,
     ) -> Option<RichTerm> {
-        let Ok(uri) = fluent_uri::Uri::parse(reference) else {
-            eprintln!(
-                "Warning: skipping reference `{reference}` (replaced by an always succeeding \
-                contract). Failed to parse it as valid URI."
-            );
-
-            return None;
-        };
-
-        // If the URI has anything else than a fragment, we bail out.
-        if uri.scheme().is_some()
-            || uri.authority().is_some()
-            || !uri.path().as_str().is_empty()
-            || uri.query().is_some()
-        {
-            eprintln!(
-                "Warning: skipping external reference `{reference}` (replaced by an always \
-                succeeding contract). The current version of json-schema-to-nickel only supports \
-                internal references"
-            );
-
-            return None;
-        }
-
-        // We don't support (yet) relative fragments.
-        let Some(fragment) = uri
-            .fragment()
-            .map(|fragment| fragment.decode().into_string_lossy())
-        else {
-            eprintln!(
-                "Warning: skipping reference `{reference}` (replaced by an always succeeding \
-                contract). The URI doesn't have a fragment"
-            );
-
-            return None;
-        };
-
-        let Some(stripped) = fragment.strip_prefix('/') else {
-            eprintln!(
-                "Warning: skipping reference `{reference}` (replaced by an always succeeding \
-                contract). json-schema-to-nickel doesn't handle references to element ids."
-            );
-
-            return None;
-        };
-
-        let schema_ptr = match SchemaPointer::parse(stripped) {
-            Ok(ptr) => ptr,
-            Err(err) => {
-                eprintln!(
-                    "Warning: skipping reference `{reference}` (replaced by an always \
-                    succeeding contract). {err}"
-                );
-
-                return None;
-            }
-        };
-
+        let schema_ptr = resolve_ptr(reference)?;
         refs_usage.record_usage(schema_ptr.clone(), usage);
         Some(schema_ptr.access(usage))
     }
@@ -772,7 +775,7 @@ impl Environment {
 
                     let term = match usage {
                         RefUsageContext::Contract => schema
-                            .try_as_contract(&mut new_refs_usage)
+                            .try_as_contract(root_schema, &mut new_refs_usage)
                             .unwrap_or_else(|| schema.as_predicate_contract(&mut new_refs_usage))
                             .into(),
                         RefUsageContext::Predicate => {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -61,7 +61,7 @@ use crate::{references, utils::plain_schema_types};
 ///
 /// This transformation inlines the "$ref", but it doesn't do the translation
 /// from "oneOf" to "type". For that, see [`lift_any_of_types`].
-pub fn merge_defs(root_schema: RootSchema) -> RootSchema {
+pub fn inline_defs(root_schema: RootSchema) -> RootSchema {
     let mut schema = root_schema.schema.clone();
     schema.post_visit(&mut MergeDefs { root: &root_schema });
     RootSchema {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,0 +1,335 @@
+use schemars::schema::{
+    ArrayValidation, ObjectValidation, RootSchema, Schema, SchemaObject, SingleOrVec,
+    SubschemaValidation,
+};
+
+use crate::{references, utils::plain_schema_types};
+
+// Some JSON schemas factor out common parts of schemas into definitions.
+// This causes some difficulty for our analysis because information is represented
+// in multiple different places, so this transformation tries to merge factored-out
+// parts into a single schema.
+//
+// As a motivating example, the github-workflow schema factors out
+//
+// ```json
+//    "eventObject": {
+//      "oneOf": [
+//        {
+//          "type": "object"
+//        },
+//        {
+//          "type": "null"
+//        }
+//      ],
+//      "additionalProperties": true
+//    },
+// ```
+//
+// as a definition, and then references it in various places that might instead
+// contain
+//
+// ```json
+// "type": ["object", "null"],
+// "additionalProperties": true
+// ```
+pub fn merge_defs(root_schema: RootSchema) -> RootSchema {
+    let mut schema = root_schema.schema.clone();
+    schema.post_visit(&mut MergeDefs { root: &root_schema });
+    RootSchema {
+        definitions: root_schema.definitions,
+        meta_schema: root_schema.meta_schema,
+        schema,
+    }
+}
+
+// TODO: docme
+pub fn lift_any_of_types(root_schema: RootSchema) -> RootSchema {
+    let mut schema = root_schema.schema.clone();
+    schema.post_visit(&mut UnionType { root: &root_schema });
+    RootSchema {
+        definitions: root_schema.definitions,
+        meta_schema: root_schema.meta_schema,
+        schema,
+    }
+}
+
+trait ShallowMerge: Sized {
+    fn shallow_merge(self, other: &Self) -> Option<Self>;
+}
+
+impl ShallowMerge for ObjectValidation {
+    fn shallow_merge(mut self, other: &Self) -> Option<Self> {
+        if no_clash(&self.max_properties, &other.max_properties)
+            && no_clash(&self.min_properties, &other.min_properties)
+            && no_clash(&self.property_names, &other.property_names)
+            && no_clash(&self.additional_properties, &other.additional_properties)
+            && (self.pattern_properties.is_empty() || other.pattern_properties.is_empty())
+        {
+            merge_opt(&mut self.max_properties, &other.max_properties);
+            merge_opt(&mut self.min_properties, &other.min_properties);
+            merge_opt(&mut self.property_names, &other.property_names);
+            merge_opt(
+                &mut self.additional_properties,
+                &other.additional_properties,
+            );
+            self.pattern_properties
+                .extend(other.pattern_properties.clone());
+            Some(self)
+        } else {
+            None
+        }
+    }
+}
+
+impl ShallowMerge for ArrayValidation {
+    fn shallow_merge(mut self, other: &Self) -> Option<Self> {
+        if no_clash(&self.items, &other.items)
+            && no_clash(&self.additional_items, &other.additional_items)
+            && no_clash(&self.max_items, &other.max_items)
+            && no_clash(&self.min_items, &other.min_items)
+            && no_clash(&self.unique_items, &other.unique_items)
+            && no_clash(&self.contains, &other.contains)
+        {
+            merge_opt(&mut self.items, &other.items);
+            merge_opt(&mut self.additional_items, &other.additional_items);
+            merge_opt(&mut self.max_items, &other.max_items);
+            merge_opt(&mut self.min_items, &other.min_items);
+            merge_opt(&mut self.unique_items, &other.unique_items);
+            merge_opt(&mut self.contains, &other.contains);
+            Some(self)
+        } else {
+            None
+        }
+    }
+}
+
+impl<T: ShallowMerge + Clone> ShallowMerge for Box<T> {
+    fn shallow_merge(self, other: &Self) -> Option<Self> {
+        (*self).shallow_merge(other).map(Box::new)
+    }
+}
+
+impl<T: ShallowMerge + Clone> ShallowMerge for Option<T> {
+    fn shallow_merge(self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (x, None) => Some(x),
+            (None, x) => Some(x.clone()),
+            (Some(x), Some(y)) => x.shallow_merge(y).map(Some),
+        }
+    }
+}
+
+fn no_clash<T: PartialEq>(x: &Option<T>, y: &Option<T>) -> bool {
+    x.is_none() || y.is_none() || x == y
+}
+
+fn merge_opt<T: Clone>(x: &mut Option<T>, y: &Option<T>) {
+    if x.is_none() {
+        *x = y.clone();
+    }
+}
+
+struct MergeDefs<'a> {
+    root: &'a RootSchema,
+}
+
+impl VisitorMut for MergeDefs<'_> {
+    fn visit_object(&mut self, obj: &mut SchemaObject) {
+        dbg!(&*obj);
+        if let Some(reference) = &obj.reference {
+            if let Some(referent) =
+                references::resolve_ptr(reference).and_then(|ptr| ptr.resolve(self.root))
+            {
+                match &*referent {
+                    Schema::Bool(_) => {}
+                    Schema::Object(other) => {
+                        let can_merge = no_clash(&obj.instance_type, &other.instance_type)
+                            && no_clash(&obj.format, &other.format)
+                            && no_clash(&obj.subschemas, &other.subschemas)
+                            && no_clash(&obj.number, &other.number)
+                            && no_clash(&obj.string, &other.string);
+
+                        let merged_obj = obj.object.clone().shallow_merge(&other.object);
+                        let merged_arr = obj.array.clone().shallow_merge(&other.array);
+                        dbg!(can_merge, &merged_obj, &merged_arr);
+
+                        if let (Some(merged_obj), Some(merged_arr), true) =
+                            (merged_obj, merged_arr, can_merge)
+                        {
+                            merge_opt(&mut obj.instance_type, &other.instance_type);
+                            merge_opt(&mut obj.format, &other.format);
+                            merge_opt(&mut obj.subschemas, &other.subschemas);
+                            merge_opt(&mut obj.number, &other.number);
+                            merge_opt(&mut obj.string, &other.string);
+                            obj.object = merged_obj;
+                            obj.array = merged_arr;
+
+                            // We've already resolved our reference, so just take the other one unconditionally.
+                            obj.reference = other.reference.clone();
+
+                            // At this point, we could try to follow the other
+                            // reference too. That might introduce loops though,
+                            // so let's not.
+                        }
+                    }
+                }
+            } else {
+                obj.reference.take();
+            }
+        };
+        dbg!(&*obj);
+    }
+}
+
+trait VisitorMut {
+    fn visit_object(&mut self, _obj: &mut SchemaObject) {}
+}
+
+trait PostVisit {
+    fn post_visit<V: VisitorMut>(&mut self, visitor: &mut V);
+}
+
+impl PostVisit for Schema {
+    fn post_visit<V: VisitorMut>(&mut self, visitor: &mut V) {
+        if let Schema::Object(obj) = self {
+            obj.post_visit(visitor);
+        }
+    }
+}
+
+impl PostVisit for SchemaObject {
+    fn post_visit<V: VisitorMut>(&mut self, visitor: &mut V) {
+        if let Some(subschemas) = &mut self.subschemas {
+            subschemas.post_visit(visitor);
+        }
+        if let Some(array) = &mut self.array {
+            array.post_visit(visitor);
+        }
+        if let Some(object) = &mut self.object {
+            object.post_visit(visitor);
+        }
+
+        visitor.visit_object(self);
+    }
+}
+
+impl PostVisit for SubschemaValidation {
+    fn post_visit<V: VisitorMut>(&mut self, visitor: &mut V) {
+        let children = [&mut self.all_of, &mut self.any_of, &mut self.one_of]
+            .into_iter()
+            .filter_map(|x| x.as_mut())
+            .flat_map(|schemas| schemas.iter_mut())
+            .chain(self.not.as_deref_mut())
+            .chain(self.if_schema.as_deref_mut())
+            .chain(self.then_schema.as_deref_mut())
+            .chain(self.else_schema.as_deref_mut());
+
+        for child in children {
+            child.post_visit(visitor);
+        }
+    }
+}
+impl PostVisit for ArrayValidation {
+    fn post_visit<V: VisitorMut>(&mut self, visitor: &mut V) {
+        // SingleOrVec doesn't give a way to get a mutable iterator, so this was
+        // the easiest way I found to iterate over it.
+        if let Some(items) = &mut self.items {
+            match items {
+                schemars::schema::SingleOrVec::Single(x) => x.post_visit(visitor),
+                schemars::schema::SingleOrVec::Vec(vec) => {
+                    for x in vec {
+                        x.post_visit(visitor)
+                    }
+                }
+            }
+        }
+        let children = self.additional_items.iter_mut().chain(&mut self.contains);
+        for child in children {
+            child.post_visit(visitor);
+        }
+    }
+}
+
+impl PostVisit for ObjectValidation {
+    fn post_visit<V: VisitorMut>(&mut self, visitor: &mut V) {
+        let children = self
+            .properties
+            .values_mut()
+            .chain(self.pattern_properties.values_mut())
+            .chain(self.additional_properties.as_deref_mut())
+            .chain(self.property_names.as_deref_mut());
+
+        for child in children {
+            child.post_visit(visitor);
+        }
+    }
+}
+
+struct UnionType<'a> {
+    root: &'a RootSchema,
+}
+
+impl VisitorMut for UnionType<'_> {
+    fn visit_object(&mut self, obj: &mut SchemaObject) {
+        if obj.instance_type.is_some() {
+            return;
+        }
+
+        if let Some(subschemas) = &mut obj.subschemas {
+            match (&subschemas.any_of, &subschemas.one_of) {
+                (None, Some(any_of)) | (Some(any_of), None) => {
+                    let Some(plain_types) = any_of
+                        .iter()
+                        .map(|s| plain_schema_types(s, self.root))
+                        .collect::<Option<Vec<_>>>()
+                    else {
+                        return;
+                    };
+
+                    let Some(mut plain_types) = plain_types
+                        .into_iter()
+                        .map(|tys| match tys {
+                            SingleOrVec::Single(t) => Some(*t),
+                            SingleOrVec::Vec(_) => None,
+                        })
+                        .collect::<Option<Vec<_>>>()
+                    else {
+                        return;
+                    };
+
+                    // Technically, if this is `one_of` then we should filter out any repeated types.
+                    plain_types.sort();
+                    plain_types.dedup();
+
+                    subschemas.any_of = None;
+                    subschemas.one_of = None;
+
+                    obj.instance_type = match plain_types.len() {
+                        0 => None,
+                        1 => Some(SingleOrVec::Single(Box::new(plain_types[0]))),
+                        _ => Some(SingleOrVec::Vec(plain_types)),
+                    };
+                }
+                _ => {}
+            }
+
+            // We may have made the subschema validation trivial, in which case remove it.
+            // (This could be a separate pass.)
+            if matches!(
+                **subschemas,
+                SubschemaValidation {
+                    all_of: None,
+                    any_of: None,
+                    one_of: None,
+                    not: None,
+                    if_schema: None,
+                    then_schema: None,
+                    else_schema: None
+                }
+            ) {
+                obj.subschemas = None;
+            }
+        }
+    }
+}

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -136,7 +136,6 @@ struct MergeDefs<'a> {
 
 impl VisitorMut for MergeDefs<'_> {
     fn visit_object(&mut self, obj: &mut SchemaObject) {
-        dbg!(&*obj);
         if let Some(reference) = &obj.reference {
             if let Some(referent) =
                 references::resolve_ptr(reference).and_then(|ptr| ptr.resolve(self.root))
@@ -152,7 +151,6 @@ impl VisitorMut for MergeDefs<'_> {
 
                         let merged_obj = obj.object.clone().shallow_merge(&other.object);
                         let merged_arr = obj.array.clone().shallow_merge(&other.array);
-                        dbg!(can_merge, &merged_obj, &merged_arr);
 
                         if let (Some(merged_obj), Some(merged_arr), true) =
                             (merged_obj, merged_arr, can_merge)
@@ -178,7 +176,6 @@ impl VisitorMut for MergeDefs<'_> {
                 obj.reference.take();
             }
         };
-        dbg!(&*obj);
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,12 @@
+use std::collections::HashSet;
+
 use nickel_lang_core::{
     identifier::LocIdent,
     term::{make, RichTerm},
 };
+use schemars::schema::{InstanceType, RootSchema, Schema, SchemaObject, SingleOrVec};
+
+use crate::references;
 
 pub fn static_access<I, S>(record: S, fields: I) -> RichTerm
 where
@@ -17,4 +22,77 @@ where
 /// Currently, this just amounts to replace `~0` by `~` and `~1` by `/`.
 pub fn decode_json_ptr_part(part: &str) -> String {
     part.replace("~0", "~").replace("~1", "/")
+}
+
+pub fn distinct<T: std::hash::Hash + Eq>(items: impl Iterator<Item = T>) -> bool {
+    let mut seen = HashSet::new();
+    for item in items {
+        if !seen.insert(item) {
+            return false;
+        }
+    }
+    true
+}
+
+pub fn schema_types(s: &Schema, root_schema: &RootSchema) -> Option<SingleOrVec<InstanceType>> {
+    match s {
+        Schema::Bool(_) => None,
+        Schema::Object(SchemaObject {
+            instance_type: Some(instance_type),
+            reference: None,
+            ..
+        }) => Some(instance_type.clone()),
+        Schema::Object(SchemaObject {
+            instance_type: None,
+            reference: Some(reference),
+            ..
+        }) => {
+            let ptr = references::resolve_ptr(reference)?;
+            let s = ptr.resolve(root_schema)?;
+            schema_types(&s, root_schema)
+        }
+        _ => None,
+    }
+}
+
+pub fn plain_schema_types(
+    s: &Schema,
+    root_schema: &RootSchema,
+) -> Option<SingleOrVec<InstanceType>> {
+    match s {
+        Schema::Bool(_) => None,
+        Schema::Object(SchemaObject {
+            instance_type: Some(instance_type),
+            reference: None,
+            format: None,
+            enum_values: None,
+            const_value: None,
+            subschemas: None,
+            number: None,
+            string: None,
+            array: None,
+            object: None,
+            metadata: _,
+            extensions: _,
+        }) => Some(instance_type.clone()),
+        Schema::Object(SchemaObject {
+            instance_type: None,
+            reference: Some(reference),
+            format: None,
+            enum_values: None,
+            const_value: None,
+            subschemas: None,
+            number: None,
+            string: None,
+            array: None,
+            object: None,
+            metadata: _,
+            extensions: _,
+        }) => {
+            let ptr = references::resolve_ptr(reference)?;
+            let s = ptr.resolve(root_schema)?;
+            schema_types(&s, root_schema)
+        }
+        _ => None,
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,6 +24,7 @@ pub fn decode_json_ptr_part(part: &str) -> String {
     part.replace("~0", "~").replace("~1", "/")
 }
 
+/// Returns `true` if all the elements in the iterator are distinct.
 pub fn distinct<T: std::hash::Hash + Eq>(items: impl Iterator<Item = T>) -> bool {
     let mut seen = HashSet::new();
     for item in items {
@@ -34,6 +35,10 @@ pub fn distinct<T: std::hash::Hash + Eq>(items: impl Iterator<Item = T>) -> bool
     true
 }
 
+/// If this schema specifies types, returns the specified types.
+///
+/// For example, given `{ "type": ["null", "number"], ... }` this
+/// returns `Some(["null", "number"])`.
 pub fn schema_types(s: &Schema, root_schema: &RootSchema) -> Option<SingleOrVec<InstanceType>> {
     match s {
         Schema::Bool(_) => None,
@@ -47,7 +52,7 @@ pub fn schema_types(s: &Schema, root_schema: &RootSchema) -> Option<SingleOrVec<
             reference: Some(reference),
             ..
         }) => {
-            let ptr = references::resolve_ptr(reference)?;
+            let ptr = references::parse_ref(reference)?;
             let s = ptr.resolve(root_schema)?;
             schema_types(&s, root_schema)
         }
@@ -55,6 +60,7 @@ pub fn schema_types(s: &Schema, root_schema: &RootSchema) -> Option<SingleOrVec<
     }
 }
 
+/// Is this schema nothing but a `{ "type": ... }`? If so, return the list of types.
 pub fn plain_schema_types(
     s: &Schema,
     root_schema: &RootSchema,
@@ -89,7 +95,7 @@ pub fn plain_schema_types(
             metadata: _,
             extensions: _,
         }) => {
-            let ptr = references::resolve_ptr(reference)?;
+            let ptr = references::parse_ref(reference)?;
             let s = ptr.resolve(root_schema)?;
             schema_types(&s, root_schema)
         }


### PR DESCRIPTION
This is an attempt at getting json-schema-to-nickel to produce more contracts and less predicates. Goals include making the errors more precise, and improving hover and completion in the lsp.

There are two main parts:
- a simple analysis of when `anyOf`/`oneOf` combinators can be replaced with a potentially-lazy `std.contract.any_of`. This currently triggers only when the elements of the `anyOf`/`oneOf` all have disjoint types ("types" in the json sense, so two records with different fields don't count)
- some transformations to help the analysis trigger more often. 

I think ultimately we'll want to move to a better intermediate representation: the one from `schemars` is a bit awkward for this purpose (plus, newer versions of `schemars` have moved away from that representation in favor of a plain untyped json value).

As an example, I introduced a typo into the `ci.ncl` example. The old generated contract gives

```
error: contract broken by the value of `on`
       oneOf: none of the options matched- value is not of type String
- value is not of type Array
- field `pull_request` didn't validate: extra fields [
  "branch"
]
```

while the new one gives

```
error: contract broken by the value of `pull_request`
       extra fields [
  "branch"
]
```

which I think is better. Unfortunately, they both point to a not-very-usable location. Old gives

```
     ┌─ <unknown> (generated by evaluation):1:1
     │
   1 │ { pull_request = %<closure@0x56444a447188>, push = %<closure@0x56444a4473e8>, }
     │ ------------------------------------------------------------------------------- evaluated to this value
```

while new gives

```
     ┌─ <unknown> (generated by evaluation):1:1
     │
   1 │ { branch = %<closure@0x556cc658efd8>, }
     │ --------------------------------------- evaluated to this value
```

(There are a lot of changed lines, but a big chunk of them were caused by me downloading an updated github-workflow.json from schemastore)