### PR TITLE
Disable the magic nix cache

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,9 +46,6 @@ jobs:
           experimental-features = nix-command flakes
           accept-flake-config = true
 
-    - name: Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
-
     - name: Run all checks
       run: |
         nix flake check --print-build-logs


### PR DESCRIPTION
The magic nix cache doesn't work anymore, so remove it. This means we have no caching in CI, which isn't ideal. But maybe our build times aren't too long?