### PR TITLE
Prepare to release the lib

### DIFF
--- a/lib/Nickel-pkg.ncl
+++ b/lib/Nickel-pkg.ncl
@@ -1,6 +1,7 @@
 {
   name = "json-schema-lib",
   description = "A library of predicates for JSON schema",
-  minimal_nickel_version = "1.12.0",
+  minimal_nickel_version = "1.14.0",
+  version = "0.1.0",
   authors = ["The json-schema-to-nickel authors"],
 } | std.package.Manifest


### PR DESCRIPTION
The minimal nickel version is set at 1.14.0 because that's the first one that allows index packages in subdirectories.